### PR TITLE
Correctly implement TIL types using the InnerRef

### DIFF
--- a/resources/idbs/README.md
+++ b/resources/idbs/README.md
@@ -1,0 +1,7 @@
+## References
+
+1. https://www.msreverseengineering.com/blog/2020/8/31/an-exhaustively-analyzed-idb-for-comrat-v4:
+
+- `ComRAT-Orchestrator.i64`
+- `FlawedGrace.idb`
+- `injected64.i64`

--- a/src/id0.rs
+++ b/src/id0.rs
@@ -125,7 +125,7 @@ pub enum IDBFunctionExtra {
 }
 
 impl IDBFunction {
-    // InnerRef: 0x38f810
+    // InnerRef 5c1b89aa-5277-4c98-98f6-cec08e1946ec 0x28f810
     fn read(key: &[u8], value: &[u8], is_64: bool) -> Result<Self> {
         let key_address = parse_number(key, true, is_64)
             .ok_or_else(|| anyhow!("Invalid IDB FileRefion Key Offset"))?;
@@ -141,7 +141,7 @@ impl IDBFunction {
         } else {
             Self::read_extra_regular(input).ok()
         };
-        // TODO Undertand the InnerRef 0x38f9d8 data
+        // TODO Undertand the InnerRef 5c1b89aa-5277-4c98-98f6-cec08e1946ec 0x28f9d8 data
         // TODO make sure all the data is parsed
         //ensure!(input.position() == u64::try_from(data.len()).unwrap());
         Ok(Self {
@@ -152,7 +152,7 @@ impl IDBFunction {
     }
 
     fn read_extra_regular(mut input: impl IdaUnpack) -> Result<IDBFunctionExtra> {
-        // TODO Undertand the sub operation at InnerRef 0x38f98f
+        // TODO Undertand the sub operation at InnerRef 5c1b89aa-5277-4c98-98f6-cec08e1946ec 0x28f98f
         let frame = input.unpack_usize_ext_max()?;
         let _unknown4 = input.unpack_dw()?;
         if _unknown4 == 0 {
@@ -173,7 +173,7 @@ impl IDBFunction {
         let _unknown1 = input.unpack_dw()?;
         let _unknown2 = input.unpack_usize_ext_max()?;
         // TODO make data depending on variables that I don't understant
-        // InnerRef: 0x38fa93
+        // InnerRef 5c1b89aa-5277-4c98-98f6-cec08e1946ec 0x28fa93
         Ok(IDBFunctionExtra::Tail { owner, refqty })
     }
 }

--- a/src/id0/root_info.rs
+++ b/src/id0/root_info.rs
@@ -863,7 +863,7 @@ pub enum NameType {
     Serial,
 }
 
-// InnerRef: 8e6e20
+// InnerRef fb47a09e-b8d8-42f7-aa80-2435c4d1e049 0x7e6e20
 impl NameType {
     fn new(value: u8) -> Option<Self> {
         Some(match value {
@@ -883,7 +883,7 @@ impl NameType {
     }
 }
 
-// InnerRef: 8e6de0
+// InnerRef fb47a09e-b8d8-42f7-aa80-2435c4d1e049 0x7e6de0
 #[derive(Debug, Clone, Copy)]
 pub enum DemNamesForm {
     /// display demangled names as comments
@@ -1164,7 +1164,7 @@ impl AbiOptions {
     }
 }
 
-// InnerRef: 8e6ee0
+// InnerRef fb47a09e-b8d8-42f7-aa80-2435c4d1e049 0x7e6ee0
 #[derive(Debug, Clone)]
 pub enum FileType {
     Raw,
@@ -1227,7 +1227,7 @@ impl FileType {
     }
 }
 
-// InnerRef: 8e6cc0
+// InnerRef fb47a09e-b8d8-42f7-aa80-2435c4d1e049 0x7e6cc0
 #[derive(Debug, Clone)]
 pub enum Compiler {
     Unknown,

--- a/src/id0/segment.rs
+++ b/src/id0/segment.rs
@@ -49,7 +49,7 @@ impl Segment {
         id0: &ID0Section,
     ) -> Result<Self> {
         let mut cursor = IdaUnpacker::new(value, is_64);
-        // InnerRef: 0x430684
+        // InnerRef 5c1b89aa-5277-4c98-98f6-cec08e1946ec 0x330684
         let startea = cursor.unpack_usize()?;
         let size = cursor.unpack_usize()?;
         let name_id = cursor.unpack_usize()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,6 +543,32 @@ mod test {
     }
 
     #[test]
+    fn parse_destructor_function() {
+        // from ComRAT-Orchestrator.i64 0x180007cf0
+        // ```c
+        // void __fastcall stringstream__basic_ios__sub_180007CF0_Destructor(
+        //   basic_ios *__shifted(stringstream,0x94) a1
+        // );
+        // ```
+        let function = [
+            0x0c, // Function Type
+            0x70, // TODO
+            0x01, // void ret
+            0x02, // n args (2 - 1 = 1)
+            0x0a, // arg0 type is pointer
+            0xfe, 0x80, 0x01, // pointer tah
+            0x3d, // pointer type is typedef
+            0x04, 0x23, 0x83, 0x69, // typedef ord is 233 -> basic_ios
+            // ?????
+            0x3d, // second typedef?
+            0x04, 0x23, 0x83, 0x66, // typedef ord is 230 => stringstream
+            0x82, 0x54, // ???? the 0x94 value?
+            0x00, // the final value always present
+        ];
+        let _til = til::Type::new_from_id0(&function).unwrap();
+    }
+
+    #[test]
     fn parse_idb_param() {
         let param = b"IDA\xbc\x02\x06metapc#\x8a\x03\x03\x02\x00\x00\x00\x00\xff_\xff\xff\xf7\x03\x00\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x0d\x00\x0d \x0d\x10\xff\xff\x00\x00\x00\xc0\x80\x00\x00\x00\x02\x02\x01\x0f\x0f\x06\xce\xa3\xbeg\xc6@\x00\x07\x00\x07\x10(FP\x87t\x09\x03\x00\x01\x13\x0a\x00\x00\x01a\x00\x07\x00\x13\x04\x04\x04\x00\x02\x04\x08\x00\x00\x00";
         let _parsed = id0::IDBParam::read(param, false).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,6 @@ impl IDBHeader {
             unk40_v5c: u32,
             unk44_zeroed: [u8; 8],
             _unk4c: [u8; 16],
-            unk5c_zeroed: [[u8; 16]; 8],
         }
 
         let v4_raw: V4Raw = bincode::deserialize_from(input)?;
@@ -347,7 +346,7 @@ impl IDBHeader {
         ensure!(v4_raw.unk38_zeroed == [0; 8], "unk38 is not zeroed");
         ensure!(v4_raw.unk40_v5c == 0x5c, "unk40 is not 0x5C");
         ensure!(v4_raw.unk44_zeroed == [0; 8], "unk44 is not zeroed");
-        ensure!(v4_raw.unk5c_zeroed == [[0; 16]; 8], "unk5c is not zeroed");
+        // TODO ensure all offsets point to after the header
 
         Ok(Self {
             magic_version: magic,
@@ -382,7 +381,6 @@ impl IDBHeader {
             unk0_v7c: u32,
             unk1_zeroed: [u8; 16],
             _unk2: [u8; 16],
-            unk3_zeroed: [[u8; 16]; 8],
         }
         let v5_raw: V5Raw = bincode::deserialize_from(input)?;
         let id0_offset =
@@ -397,7 +395,7 @@ impl IDBHeader {
         ensure!(v5_raw.seg_offset_zeroed == 0, "seg in V5 is not zeroed");
         ensure!(v5_raw.unk0_v7c == 0x7C, "unk0 not 0x7C");
         ensure!(v5_raw.unk1_zeroed == [0; 16], "unk1 is not zeroed");
-        ensure!(v5_raw.unk3_zeroed == [[0; 16]; 8], "unk3 is not zeroed");
+        // TODO ensure all offsets point to after the header
 
         Ok(Self {
             magic_version: magic,
@@ -433,7 +431,6 @@ impl IDBHeader {
             unk0_v7c: u32,
             unk1_zeroed: [u8; 16],
             _unk2: [u8; 16],
-            unk3_zeroed: [[u8; 16]; 8],
         }
         let v6_raw: V6Raw = bincode::deserialize_from(input)?;
         let id0_offset =
@@ -445,7 +442,7 @@ impl IDBHeader {
         ensure!(v6_raw.seg_offset_zeroed == 0, "seg in V6 is not zeroed");
         ensure!(v6_raw.unk0_v7c == 0x7C, "unk0 not 0x7C");
         ensure!(v6_raw.unk1_zeroed == [0; 16], "unk1 is not zeroed");
-        ensure!(v6_raw.unk3_zeroed == [[0; 16]; 8], "unk3 is not zeroed");
+        // TODO ensure all offsets point to after the header
 
         Ok(Self {
             magic_version: magic,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,13 +299,12 @@ impl IDBHeader {
             checksums: [u32; 3],
             unk30_zeroed: u32,
             unk33_checksum: u32,
-            unk38_zeroed: [u8; 6],
         }
 
         let v1_raw: V1Raw = bincode::deserialize_from(input)?;
         ensure!(v1_raw.unk30_zeroed == 0, "unk30 not zeroed");
         ensure!(v1_raw.id2_offset == 0, "id2 in V1 is not zeroed");
-        ensure!(v1_raw.unk38_zeroed == [0; 6], "unk38 is not zeroed");
+        // TODO ensure all offsets point to after the header
 
         Ok(Self {
             magic_version: magic,
@@ -335,8 +334,6 @@ impl IDBHeader {
             unk33_checksum: u32,
             unk38_zeroed: [u8; 8],
             unk40_v5c: u32,
-            unk44_zeroed: [u8; 8],
-            _unk4c: [u8; 16],
         }
 
         let v4_raw: V4Raw = bincode::deserialize_from(input)?;
@@ -345,7 +342,6 @@ impl IDBHeader {
         ensure!(v4_raw.id2_offset == 0, "id2 in V4 is not zeroed");
         ensure!(v4_raw.unk38_zeroed == [0; 8], "unk38 is not zeroed");
         ensure!(v4_raw.unk40_v5c == 0x5c, "unk40 is not 0x5C");
-        ensure!(v4_raw.unk44_zeroed == [0; 8], "unk44 is not zeroed");
         // TODO ensure all offsets point to after the header
 
         Ok(Self {
@@ -379,8 +375,6 @@ impl IDBHeader {
             id2_offset_zeroed: u64,
             final_checksum: u32,
             unk0_v7c: u32,
-            unk1_zeroed: [u8; 16],
-            _unk2: [u8; 16],
         }
         let v5_raw: V5Raw = bincode::deserialize_from(input)?;
         let id0_offset =
@@ -394,7 +388,6 @@ impl IDBHeader {
         ensure!(v5_raw.id2_offset_zeroed == 0, "id2 in V5 is not zeroed");
         ensure!(v5_raw.seg_offset_zeroed == 0, "seg in V5 is not zeroed");
         ensure!(v5_raw.unk0_v7c == 0x7C, "unk0 not 0x7C");
-        ensure!(v5_raw.unk1_zeroed == [0; 16], "unk1 is not zeroed");
         // TODO ensure all offsets point to after the header
 
         Ok(Self {
@@ -429,8 +422,6 @@ impl IDBHeader {
             id2_offset: u64,
             final_checksum: u32,
             unk0_v7c: u32,
-            unk1_zeroed: [u8; 16],
-            _unk2: [u8; 16],
         }
         let v6_raw: V6Raw = bincode::deserialize_from(input)?;
         let id0_offset =
@@ -441,7 +432,6 @@ impl IDBHeader {
         ensure!(v6_raw.unk4_zeroed == [0; 4], "unk4 not zeroed");
         ensure!(v6_raw.seg_offset_zeroed == 0, "seg in V6 is not zeroed");
         ensure!(v6_raw.unk0_v7c == 0x7C, "unk0 not 0x7C");
-        ensure!(v6_raw.unk1_zeroed == [0; 16], "unk1 is not zeroed");
         // TODO ensure all offsets point to after the header
 
         Ok(Self {

--- a/src/til.rs
+++ b/src/til.rs
@@ -119,7 +119,7 @@ impl Type {
         // maybe it just use the til sector header, or more likelly it's from
         // IDBParam  in the `Root Node`
         let header = section::TILSectionHeader {
-            format: 700,
+            format: 12,
             flags: section::TILSectionFlag(0),
             title: Vec::new(),
             description: Vec::new(),
@@ -145,7 +145,7 @@ impl Type {
                 return Err(anyhow!(
                     "Extra {} bytes after reading TIL from ID0",
                     rest.len()
-                ))
+                ));
             }
         }
         Self::new(&header, type_raw, None)

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -80,6 +80,7 @@ impl EnumRaw {
     ) -> anyhow::Result<Self> {
         let Some(n) = input.read_dt_de()? else {
             // is ref
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
             let taenum_bits = SDACL::read(&mut *input)?.0;
             return Ok(EnumRaw::Ref {

--- a/src/til/pointer.rs
+++ b/src/til/pointer.rs
@@ -52,6 +52,7 @@ impl PointerRaw {
         metadata: u8,
     ) -> anyhow::Result<Self> {
         use crate::til::flag::tf_ptr::*;
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x478d67
         let closure = match metadata {
             BTMT_DEFPTR => None,
             BTMT_CLOSURE => Some(ClosureRaw::read(&mut *input, header)?),
@@ -60,6 +61,7 @@ impl PointerRaw {
             BTMT_NEAR => None,
             _ => unreachable!(),
         };
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4804fa
         let tah = TAH::read(&mut *input)?;
         let typ = TypeRaw::read(&mut *input, header)?;
         Ok(Self {

--- a/src/til/pointer.rs
+++ b/src/til/pointer.rs
@@ -53,6 +53,7 @@ impl PointerRaw {
     ) -> anyhow::Result<Self> {
         use crate::til::flag::tf_ptr::*;
         // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x478d67
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459b54
         let closure = match metadata {
             BTMT_DEFPTR => None,
             BTMT_CLOSURE => Some(ClosureRaw::read(&mut *input, header)?),
@@ -62,8 +63,15 @@ impl PointerRaw {
             _ => unreachable!(),
         };
         // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4804fa
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459b7e
         let tah = TAH::read(&mut *input)?;
         let typ = TypeRaw::read(&mut *input, header)?;
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459bc6
+        if tah.0 .0 & 0x80 != 0 {
+            // TODO __shifted?
+            let _typ = TypeRaw::read(&mut *input, header)?;
+            let _value = input.read_de()?;
+        }
         Ok(Self {
             closure,
             tah,

--- a/src/til/struct.rs
+++ b/src/til/struct.rs
@@ -1,7 +1,7 @@
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
 use crate::til::{associate_field_name_and_member, Type, TypeRaw, SDACL};
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result};
 
 #[derive(Clone, Debug)]
 pub enum Struct {
@@ -20,7 +20,7 @@ impl Struct {
         til: &TILSectionHeader,
         value: StructRaw,
         fields: Option<Vec<Vec<u8>>>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         match value {
             StructRaw::Ref {
                 ref_type,
@@ -67,11 +67,10 @@ pub(crate) enum StructRaw {
 }
 
 impl StructRaw {
-    pub fn read(
-        input: &mut impl IdaGenericBufUnpack,
-        header: &TILSectionHeader,
-    ) -> anyhow::Result<Self> {
+    pub fn read(input: &mut impl IdaGenericBufUnpack, header: &TILSectionHeader) -> Result<Self> {
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459883
         let Some(n) = input.read_dt_de()? else {
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             // simple reference
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
             let taudt_bits = SDACL::read(&mut *input)?;
@@ -81,13 +80,15 @@ impl StructRaw {
             });
         };
 
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4808f9
         let alpow = n & 7;
         let mem_cnt = n >> 3;
         let effective_alignment = if alpow == 0 { 0 } else { 1 << (alpow - 1) };
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459c97
         let taudt_bits = SDACL::read(&mut *input)?;
         let members = (0..mem_cnt)
-            .map(|_| StructMemberRaw::read(&mut *input, header))
-            .collect::<anyhow::Result<_, _>>()?;
+            .map(|_| StructMemberRaw::read(&mut *input, header, taudt_bits.0 .0))
+            .collect::<Result<_, _>>()?;
         Ok(Self::NonRef {
             effective_alignment,
             taudt_bits,
@@ -104,28 +105,98 @@ pub struct StructMember {
 }
 
 impl StructMember {
-    fn new(
-        til: &TILSectionHeader,
-        name: Option<Vec<u8>>,
-        m: StructMemberRaw,
-    ) -> anyhow::Result<Self> {
+    fn new(til: &TILSectionHeader, name: Option<Vec<u8>>, m: StructMemberRaw) -> Result<Self> {
         Ok(Self {
             name,
-            member_type: Type::new(til, m.0, None)?,
-            sdacl: m.1,
+            member_type: Type::new(til, m.ty, None)?,
+            sdacl: m.sdacl,
         })
     }
 }
 #[derive(Clone, Debug)]
-pub(crate) struct StructMemberRaw(pub TypeRaw, pub SDACL);
+pub(crate) struct StructMemberRaw {
+    pub ty: TypeRaw,
+    pub sdacl: SDACL,
+}
 
 impl StructMemberRaw {
     fn read(
         input: &mut impl IdaGenericBufUnpack,
         header: &TILSectionHeader,
-    ) -> anyhow::Result<Self> {
-        let member_type = TypeRaw::read(&mut *input, header)?;
-        let sdacl = SDACL::read(&mut *input)?;
-        Ok(Self(member_type, sdacl))
+        taudt_bits: u16,
+    ) -> Result<Self> {
+        let ty = TypeRaw::read(&mut *input, header)?;
+
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x478203
+        let is_bit_set = taudt_bits & 0x200 != 0;
+
+        let mut att1 = None;
+        if is_bit_set {
+            att1 = Self::read_member_att_1(input, header)?;
+        }
+
+        //// InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x47825d
+        let mut sdacl = SDACL(crate::til::TypeAttribute(0));
+        if !is_bit_set || matches!(att1, Some(_att1)) {
+            sdacl = SDACL::read(&mut *input)?;
+            // TODO there is more to this impl
+            //todo!();
+        }
+
+        Ok(Self { ty, sdacl })
+    }
+
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486cd0
+    fn read_member_att_1(
+        input: &mut impl IdaGenericBufUnpack,
+        _header: &TILSectionHeader,
+    ) -> Result<Option<u64>> {
+        let Some(att) = input.read_ext_att()? else {
+            return Ok(None);
+        };
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486d0d
+        match att & 0xf {
+            0xd..=0xf => return Err(anyhow!("Invalid value for member attribute {att:#x}")),
+            0..=7 => Self::basic_att(input, att),
+            8 | 0xb => todo!(),
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486d3f
+            9 => {
+                let val1 = input.read_de()?;
+                if val1 & 0x1010 == 0 {
+                    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486f8d
+                    let _att = input
+                        .read_ext_att()?
+                        .ok_or_else(|| anyhow!("Unable to read att of type 9"))?;
+                }
+
+                let _att1 = input
+                    .read_ext_att()?
+                    .ok_or_else(|| anyhow!("Unable to read att of type 9"))?;
+                let _att2 = input
+                    .read_ext_att()?
+                    .ok_or_else(|| anyhow!("Unable to read att of type 9"))?;
+                // TODO find this value
+                Ok(Some(_att2))
+            }
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486e50
+            0xa | 0xc => {
+                let _val1 = input.read_de()?;
+                Self::basic_att(input, att)
+            }
+            0x10.. => unreachable!(),
+        }
+    }
+
+    fn basic_att(input: &mut impl IdaGenericBufUnpack, att: u64) -> Result<Option<u64>> {
+        if att & 0x10 != 0 {
+            // TODO this is diferent from the implementation, double check the read_de and this code
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486df0
+            let _val1 = input.read_de()?;
+            //let _val2 = input.read_de()?;
+            //let _val3 = input.read_de()?;
+            Ok(Some(att))
+        } else {
+            Ok(Some(att))
+        }
     }
 }

--- a/src/til/struct.rs
+++ b/src/til/struct.rs
@@ -132,15 +132,23 @@ impl StructMemberRaw {
 
         let mut att1 = None;
         if is_bit_set {
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x478256
             att1 = Self::read_member_att_1(input, header)?;
         }
 
-        //// InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x47825d
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x47825d
         let mut sdacl = SDACL(crate::til::TypeAttribute(0));
         if !is_bit_set || matches!(att1, Some(_att1)) {
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x47825d
             sdacl = SDACL::read(&mut *input)?;
-            // TODO there is more to this impl
-            //todo!();
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x47822d
+            if taudt_bits & 4 != 0 {
+                if sdacl.0 .0 & 0x200 == 0 {
+                    // TODO there is more to this impl?
+                    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x478411
+                    // todo!();
+                }
+            }
         }
 
         Ok(Self { ty, sdacl })
@@ -188,12 +196,12 @@ impl StructMemberRaw {
     }
 
     fn basic_att(input: &mut impl IdaGenericBufUnpack, att: u64) -> Result<Option<u64>> {
-        if att & 0x10 != 0 {
+        if (att >> 8) & 0x10 != 0 {
             // TODO this is diferent from the implementation, double check the read_de and this code
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x486df0
             let _val1 = input.read_de()?;
-            //let _val2 = input.read_de()?;
-            //let _val3 = input.read_de()?;
+            let _val2 = input.read_de()?;
+            let _val3 = input.read_de()?;
             Ok(Some(att))
         } else {
             Ok(Some(att))

--- a/src/til/union.rs
+++ b/src/til/union.rs
@@ -74,6 +74,7 @@ impl UnionRaw {
         header: &TILSectionHeader,
     ) -> anyhow::Result<Self> {
         let Some(n) = input.read_dt_de()? else {
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             // is ref
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
             let taudt_bits = SDACL::read(&mut *input)?;
@@ -82,6 +83,8 @@ impl UnionRaw {
                 taudt_bits,
             });
         };
+
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4808f9
         let alpow = n & 7;
         let mem_cnt = n >> 3;
         let effective_alignment = if alpow == 0 { 0 } else { 1 << (alpow - 1) };

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use anyhow::{anyhow, Result};
-use idb_rs::til::section::{TILSection, TILSizes};
+use idb_rs::til::section::TILSection;
 use idb_rs::til::TILMacro;
 use idb_rs::IDBParser;
 
@@ -33,10 +33,12 @@ pub fn dump_til(args: &Args) -> Result<()> {
         id,
         cm,
         def_align,
-        type_ordinal_numbers,
+        type_ordinal_alias,
         size_i,
         size_b,
-        sizes,
+        size_short,
+        size_long,
+        size_long_long,
         size_long_double,
         is_universal,
         symbols,
@@ -53,22 +55,15 @@ pub fn dump_til(args: &Args) -> Result<()> {
     println!("size_i: {size_i}");
     println!("size_b: {size_b}");
     println!("is_universal: {is_universal}");
-    if let Some(type_ordinal_numbers) = type_ordinal_numbers {
+    if let Some(type_ordinal_numbers) = type_ordinal_alias {
         println!("type_ordinal_numbers: {type_ordinal_numbers:?}");
     }
     if let Some(size_long_double) = size_long_double {
         println!("size_long_double: {size_long_double}");
     }
-    if let Some(TILSizes {
-        size_short,
-        size_long,
-        size_long_long,
-    }) = sizes
-    {
-        println!("size short: {size_short}");
-        println!("size long: {size_long}");
-        println!("size long_long: {size_long_long}");
-    }
+    println!("size short: {size_short}");
+    println!("size long: {size_long}");
+    println!("size long_long: {size_long_long}");
 
     // TODO implement Display for TILTypeInfo
     println!("types:");


### PR DESCRIPTION
Current implementation is good enough to fix:
* [x]  #12
* [x]  PayloadRestrictions.dll.i64
* [x]  #10
* [x]  #9
* [x]  #8
* [x]  #17 