### PR TITLE
Extra Til parsing check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,3 @@ num_enum = "0.7.3"
 [[bin]]
 name = "idb-tools"
 path = "src/tools/tools.rs"
-
-
-[[bin]]
-name = "tilib"
-path = "src/tools/tilib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5", features = ["derive"] }
 bincode = "1.3.3"
 flate2 = "1.0.31"
 serde = { version = "1.0", features = ["derive"] }
+num_enum = "0.7.3"
 
 [[bin]]
 name = "idb-tools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 [[bin]]
 name = "idb-tools"
 path = "src/tools/tools.rs"
+
+
+[[bin]]
+name = "tilib"
+path = "src/tools/tilib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ clap = { version = "4.5", features = ["derive"] }
 bincode = "1.3.3"
 flate2 = "1.0.31"
 serde = { version = "1.0", features = ["derive"] }
-itertools = "0.13.0"
 
 [[bin]]
 name = "idb-tools"

--- a/src/id0/address_info.rs
+++ b/src/id0/address_info.rs
@@ -170,9 +170,9 @@ impl<'a> Iterator for AddressInfoIter<'a> {
                         let Some(fields) = crate::ida_reader::split_strings_from_array(value) else {
                             return Some(Err(anyhow!("Invalid Fields for TIL Type")));
                         };
-                        (Some(fields), rest)
+                        (fields, rest)
                     }
-                    rest => (None, rest),
+                    rest => (vec![], rest),
                 };
 
                 // condensate the data into a single buffer

--- a/src/id0/btree.rs
+++ b/src/id0/btree.rs
@@ -594,12 +594,7 @@ impl ID0Section {
             let key = parse_number(key, true, self.is_64).unwrap();
             // TODO handle other values for the key
             if key == key_find {
-                let til_type = til::Type::new_from_id0(&entry.value, None)
-                    .map(Option::Some)
-                    .map_err(|e| {
-                        todo!("Error parsing {:#04x?}: {e:?}", &entry.value);
-                    });
-                return til_type;
+                return til::Type::new_from_id0(&entry.value, None).map(Option::Some);
             }
         }
         Ok(None)

--- a/src/id0/btree.rs
+++ b/src/id0/btree.rs
@@ -594,7 +594,7 @@ impl ID0Section {
             let key = parse_number(key, true, self.is_64).unwrap();
             // TODO handle other values for the key
             if key == key_find {
-                return til::Type::new_from_id0(&entry.value, None).map(Option::Some);
+                return til::Type::new_from_id0(&entry.value, vec![]).map(Option::Some);
             }
         }
         Ok(None)

--- a/src/id0/dirtree.rs
+++ b/src/id0/dirtree.rs
@@ -66,7 +66,8 @@ impl Id0AddressKey for Id0Address {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Id0TilOrd {
-    pub(crate) ord: u64,
+    // TODO remove this pub
+    pub ord: u64,
 }
 impl FromDirTreeNumber for Id0TilOrd {
     #[inline]

--- a/src/id0/root_info.rs
+++ b/src/id0/root_info.rs
@@ -1228,7 +1228,7 @@ impl FileType {
 }
 
 // InnerRef fb47a09e-b8d8-42f7-aa80-2435c4d1e049 0x7e6cc0
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Compiler {
     Unknown,
     VisualStudio,

--- a/src/ida_reader.rs
+++ b/src/ida_reader.rs
@@ -418,19 +418,15 @@ pub trait IdaGenericUnpack: Read {
     fn read_de(&mut self) -> Result<u32> {
         // TODO check if the implementation is complete
         // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x48cdb0
-        let mut val: u32 = 0;
+        let mut acc: u32 = 0;
         for _ in 0..5 {
-            let mut hi = val << 6;
             let b: u32 = self.read_u8()?.into();
             if b & 0x80 == 0 {
-                let lo = b & 0x3F;
-                val = lo | hi;
-                return Ok(val);
-            } else {
-                let lo = 2 * hi;
-                hi = b & 0x7F;
-                val = lo | hi;
+                acc = (b & 0x3F) | (acc << 6);
+                return Ok(acc);
             }
+
+            acc = (acc << 7) | (b & 0x7F);
         }
         Err(anyhow!("Can't find the end of DE"))
     }

--- a/src/ida_reader.rs
+++ b/src/ida_reader.rs
@@ -439,8 +439,9 @@ pub trait IdaGenericUnpack: Read {
         let value = match self.read_u8()? {
             0 => return Err(anyhow!("DT can't have 0 value")),
             //SEG = 2
-            value if value & 0x80 != 0 => {
+            value @ 0x80.. => {
                 let inter: u16 = self.read_u8()?.into();
+                ensure!(inter != 0, "DT can't have a following 0 value");
                 value as u16 & 0x7F | inter << 7
             }
             //SEG = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,7 +539,7 @@ mod test {
             0x3d, 0x08, 0x48, 0x4d, 0x4f, 0x44, 0x55, 0x4c, 0x45, 0x3d, 0x06, 0x44, 0x57, 0x4f,
             0x52, 0x44, 0x00,
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]
@@ -565,7 +565,7 @@ mod test {
             0x82, 0x54, // ???? the 0x94 value?
             0x00, // the final value always present
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]
@@ -605,7 +605,7 @@ mod test {
             0x67, // "__jmp_buf_tag"
             0x00, // end of type
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]
@@ -660,7 +660,7 @@ mod test {
             0x27, // unsigned int
             0x00,
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]
@@ -693,7 +693,7 @@ mod test {
             0x05, 0x55, 0x49, 0x4e, 0x54, // typedef name
             0x00, //end
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]
@@ -725,7 +725,7 @@ mod test {
             0x01, // no params
             0x00, // end
         ];
-        let _til = til::Type::new_from_id0(&function, None).unwrap();
+        let _til = til::Type::new_from_id0(&function, vec![]).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,6 +569,101 @@ mod test {
     }
 
     #[test]
+    fn parse_function_ext_att() {
+        // ```
+        // Function {
+        //   ret: Basic(Int { bytes: 4, is_signed: None }),
+        //   args: [(
+        //     Some("env"),
+        //     Pointer(Pointer {
+        //       closure: Default,
+        //       tah: TAH(TypeAttribute(1)),
+        //       typ: Struct(Ref {
+        //         ref_type: Typedef("__jmp_buf_tag"),
+        //         taudt_bits: SDACL(TypeAttribute(0))
+        //       })
+        //     }),
+        //     None
+        //   )],
+        //   retloc: None }
+        // ```
+        let function = [
+            0x0c, // func type
+            0x13, // TODO
+            0x07, // return int
+            0x02, // 1 parameter
+            0xff, 0x48, // TODO
+            0x0a, // arg1 type pointer
+            0xfe, 0x10, // TypeAttribute val
+            0x02, // dt len 1
+            0x0d, 0x5f, 0x5f, 0x6f, 0x72, 0x67, 0x5f, 0x61, 0x72, 0x72, 0x64, 0x69,
+            0x6d, // TODO some _string: "__org_arrdim"
+            0x03, 0xac, 0x01, // TODO _other_thing
+            0x0d, // arg1 pointer type struct
+            0x01, // struct ref
+            0x0e, 0x5f, 0x5f, 0x6a, 0x6d, 0x70, 0x5f, 0x62, 0x75, 0x66, 0x5f, 0x74, 0x61,
+            0x67, // "__jmp_buf_tag"
+            0x00, // end of type
+        ];
+        let _til = til::Type::new_from_id0(&function, None).unwrap();
+    }
+
+    #[test]
+    fn parse_aes_encrypt() {
+        // ```c
+        // void AES_ctr128_encrypt(
+        //   const unsigned __int8 *in,
+        //   unsigned __int8 *out,
+        //   const unsigned int length,
+        //   const AES_KEY *key,
+        //   unsigned __int8 ivec[16],
+        //   unsigned __int8 ecount_buf[16],
+        //   unsigned int *num
+        // );
+        // ```
+        let function = [
+            0x0c, // type function
+            0x13, 0x01, // ???
+            0x08, // 7 args
+            // arg1 ...
+            0x0a, // pointer
+            0x62, // const unsigned __int8
+            // arg2 ...
+            0x0a, // pointer
+            0x22, // unsigned __int8
+            // arg3 ...
+            0x67, // const unsigned int
+            // arg4 ...
+            0x0a, // pointer
+            0x7d, // const typedef
+            0x08, 0x41, 0x45, 0x53, 0x5f, 0x4b, 0x45, 0x59, // ordinal "AES_KEY"
+            // arg5
+            0xff, 0x48, // some flag in function arg
+            0x0a, // pointer
+            0xfe, 0x10, // TypeAttribute val
+            0x02, // TypeAttribute loop once
+            0x0d, 0x5f, 0x5f, 0x6f, 0x72, 0x67, 0x5f, 0x61, 0x72, 0x72, 0x64, 0x69,
+            0x6d, // string "__org_arrdim"
+            0x03, 0xac, 0x10, // ???? some other TypeAttribute field
+            0x22, // type unsigned __int8
+            // arg6
+            0xff, 0x48, // some flag in function arg
+            0x0a, // pointer
+            0xfe, 0x10, // TypeAttribute val
+            0x02, // TypeAttribute loop once
+            0x0d, 0x5f, 0x5f, 0x6f, 0x72, 0x67, 0x5f, 0x61, 0x72, 0x72, 0x64, 0x69,
+            0x6d, // string "__org_arrdim"
+            0x03, 0xac, 0x10, // ???? some other TypeAttribute field
+            0x22, // type unsigned __int8
+            // arg7 ...
+            0x0a, // pointer
+            0x27, // unsigned int
+            0x00,
+        ];
+        let _til = til::Type::new_from_id0(&function, None).unwrap();
+    }
+
+    #[test]
     fn parse_idb_param() {
         let param = b"IDA\xbc\x02\x06metapc#\x8a\x03\x03\x02\x00\x00\x00\x00\xff_\xff\xff\xf7\x03\x00\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x0d\x00\x0d \x0d\x10\xff\xff\x00\x00\x00\xc0\x80\x00\x00\x00\x02\x02\x01\x0f\x0f\x06\xce\xa3\xbeg\xc6@\x00\x07\x00\x07\x10(FP\x87t\x09\x03\x00\x01\x13\x0a\x00\x00\x01a\x00\x07\x00\x13\x04\x04\x04\x00\x02\x04\x08\x00\x00\x00";
         let _parsed = id0::IDBParam::read(param, false).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,6 +664,71 @@ mod test {
     }
 
     #[test]
+    fn parse_spoiled_function_kernel_32() {
+        // ```
+        // TilType(Type { is_const: false, is_volatile: false, type_variant:
+        //   Function(Function {
+        //     ret: Type { is_const: false, is_volatile: false, type_variant: Basic(Void) },
+        //     args: [
+        //       (
+        //         Some([117, 69, 120, 105, 116, 67, 111, 100, 101]),
+        //         Type {
+        //           is_const: false,
+        //           is_volatile: false,
+        //           type_variant: Typedef(Name([85, 73, 78, 84])) }, None)],
+        //           retloc: None
+        //         }
+        //       )
+        // })
+        // ```
+        let function = [
+            0x0c, // function type
+            0xaf, 0x81, // function cc extended...
+            0x42, // flag
+            0x01, // 0 regs nspoiled
+            0x53, // cc
+            0x01, // return type void
+            0x02, // 1 param
+            0x3d, // param 1 typedef
+            0x05, 0x55, 0x49, 0x4e, 0x54, // typedef name
+            0x00, //end
+        ];
+        let _til = til::Type::new_from_id0(&function, None).unwrap();
+    }
+
+    #[test]
+    fn parse_spoiled_function_invalid_reg() {
+        // ```
+        // 0x180001030:
+        // TilType(Type { is_const: false, is_volatile: false, type_variant:
+        //   Function(Function {
+        //     ret: Type { is_const: false, is_volatile: false, type_variant: Basic(Void) },
+        //     args: [], retloc: None
+        //   })
+        // })
+        // ```
+        let function = [
+            0x0c, // function type
+            0xaa, // extended function cc, 10 nspoiled
+            0x71, // spoiled reg 0
+            0x72, // spoiled reg 1
+            0x73, // spoiled reg 2
+            0x79, // spoiled reg 3
+            0x7a, // spoiled reg 4
+            0x7b, // spoiled reg 5
+            0x7c, // spoiled reg 6
+            0xc0, 0x08, // spoiled reg 7
+            0xc4, 0x08, // spoiled reg 8
+            0xc5, 0x08, // spoiled reg 9
+            0x30, // cc
+            0x01, // return type void
+            0x01, // no params
+            0x00, // end
+        ];
+        let _til = til::Type::new_from_id0(&function, None).unwrap();
+    }
+
+    #[test]
     fn parse_idb_param() {
         let param = b"IDA\xbc\x02\x06metapc#\x8a\x03\x03\x02\x00\x00\x00\x00\xff_\xff\xff\xf7\x03\x00\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x0d\x00\x0d \x0d\x10\xff\xff\x00\x00\x00\xc0\x80\x00\x00\x00\x02\x02\x01\x0f\x0f\x06\xce\xa3\xbeg\xc6@\x00\x07\x00\x07\x10(FP\x87t\x09\x03\x00\x01\x13\x0a\x00\x00\x01a\x00\x07\x00\x13\x04\x04\x04\x00\x02\x04\x08\x00\x00\x00";
         let _parsed = id0::IDBParam::read(param, false).unwrap();

--- a/src/til.rs
+++ b/src/til.rs
@@ -249,6 +249,7 @@ impl TypeRaw {
                 .context("Type::Array")
                 .map(TypeVariantRaw::Array)?,
 
+            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x48055d
             (flag::tf_func::BT_FUNC, _) => FunctionRaw::read(input, til, type_flags)
                 .context("Type::Function")
                 .map(TypeVariantRaw::Function)?,

--- a/src/til.rs
+++ b/src/til.rs
@@ -257,7 +257,7 @@ impl Type {
                 }
                 max
             }
-            Type::Enum(Enum::NonRef { bytesize, .. }) => bytesize
+            Type::Enum(Enum::NonRef { storage_size, .. }) => storage_size
                 .or(section.size_enum)
                 .map(|x| x.get())
                 .unwrap_or(4)

--- a/src/til.rs
+++ b/src/til.rs
@@ -212,11 +212,11 @@ impl Type {
             Type::Function(_) => 0, // function type dont have a size, only a pointer to it
             Type::Array(array) => array.elem_type.type_size_bytes(section)? * array.nelem as u64,
             Type::Typedef(Typedef::Name(name)) => section
-                .get_name(&name)
+                .get_name(name)
                 .ok_or_else(|| {
                     anyhow!(
                         "Unable to find typedef by name: {}",
-                        String::from_utf8_lossy(&name)
+                        String::from_utf8_lossy(name)
                     )
                 })?
                 .tinfo
@@ -240,9 +240,9 @@ impl Type {
                         section.def_align as u64
                     };
                     if align != 0 {
-                        let align_diff = sum % align as u64;
+                        let align_diff = sum % align;
                         if align_diff != 0 {
-                            sum += align as u64 - align_diff;
+                            sum += align - align_diff;
                         }
                     }
                     sum += field_size;

--- a/src/til.rs
+++ b/src/til.rs
@@ -114,7 +114,7 @@ pub enum TypeVariant {
     Struct(Struct),
     Union(Union),
     Enum(Enum),
-    // TODO narrow what kinds od Type can be inside the Ref
+    // TODO narrow what kinds of Type can be inside the Ref
     StructRef(Box<Type>),
     UnionRef(Box<Type>),
     EnumRef(Box<Type>),

--- a/src/til.rs
+++ b/src/til.rs
@@ -654,18 +654,6 @@ impl TILMacro {
     }
 }
 
-#[derive(Clone, Default, Debug)]
-pub struct TypeMetadata(pub u8);
-impl TypeMetadata {
-    fn new(value: u8) -> Self {
-        // TODO check for invalid values
-        Self(value)
-    }
-    fn read(input: &mut impl IdaGenericUnpack) -> Result<Self> {
-        Ok(Self::new(input.read_u8()?))
-    }
-}
-
 // TODO make those inner fields into enums or private
 #[derive(Clone, Copy, Debug)]
 pub struct BaseTypeFlag(pub u8);
@@ -757,38 +745,6 @@ impl SDACL {
             0xd0..=0xff | 0xc0 | 0xc1 => Ok(Self(TypeAttribute::read(input)?)),
             _ => Ok(Self(TypeAttribute(0))),
         }
-    }
-}
-
-impl CallingConventionFlag {
-    fn is_spoiled(&self) -> bool {
-        self.0 == 0xA0
-    }
-
-    fn is_void_arg(&self) -> bool {
-        self.0 == 0x20
-    }
-
-    fn is_special_pe(&self) -> bool {
-        self.0 == 0xD0 || self.0 == 0xE0 || self.0 == 0xF0
-    }
-}
-
-impl TypeMetadata {
-    pub fn get_base_type_flag(&self) -> BaseTypeFlag {
-        BaseTypeFlag(self.0 & flag::tf_mask::TYPE_BASE_MASK)
-    }
-
-    pub fn get_full_type_flag(&self) -> FullTypeFlag {
-        FullTypeFlag(self.0 & flag::tf_mask::TYPE_FULL_MASK)
-    }
-
-    pub fn get_type_flag(&self) -> TypeFlag {
-        TypeFlag(self.0 & flag::tf_mask::TYPE_FLAGS_MASK)
-    }
-
-    pub fn get_calling_convention(&self) -> CallingConventionFlag {
-        CallingConventionFlag(self.0 & 0xF0)
     }
 }
 

--- a/src/til.rs
+++ b/src/til.rs
@@ -259,8 +259,6 @@ impl TypeRaw {
             ),
 
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x480369
-
-            // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x480369
             (flag::tf_complex::BT_COMPLEX, flag::tf_complex::BTMT_TYPEDEF) => Typedef::read(input)
                 .context("Type::Typedef")
                 .map(TypeVariantRaw::Typedef)?,

--- a/src/til.rs
+++ b/src/til.rs
@@ -160,9 +160,7 @@ impl Type {
             size_bool: 1.try_into().unwrap(),
             def_align: 0,
             size_long_double: None,
-            size_short: 2.try_into().unwrap(),
-            size_long: 4.try_into().unwrap(),
-            size_long_long: 8.try_into().unwrap(),
+            extended_sizeof_info: None,
         };
         let mut reader = data;
         let type_raw = TypeRaw::read(&mut reader, &header)?;

--- a/src/til.rs
+++ b/src/til.rs
@@ -180,6 +180,7 @@ impl Type {
         Self::new(&header, type_raw, fields)
     }
 
+    // TODO stub implementation
     pub fn type_size_bytes(&self, section: &TILSection) -> Result<u64> {
         fn addr_size(section: &TILSection) -> u64 {
             section

--- a/src/til.rs
+++ b/src/til.rs
@@ -582,7 +582,7 @@ impl TILMacro {
                     let param_idx = c & 0x7F;
                     if !have_param && matches!(param_idx, 0x20 | 0x25 | 0x29) {
                         // HACK: it's known that some macros, although having no params
-                        // include some params in the value, It's unknown the menaing of those,
+                        // include some params in the value, It's unknown the meaning of those,
                         // maybe they are just bugs.
                         return None;
                     }

--- a/src/til.rs
+++ b/src/til.rs
@@ -779,7 +779,6 @@ impl StructModifierRaw {
         let alignment_raw = value & TAUDT_ALIGN_MASK;
         let alignment =
             (alignment_raw != 0).then(|| NonZeroU16::new(1 << (alignment_raw - 1)).unwrap());
-        // __attribute__((packed)) == Unaligned & Other(0x8)
         let all_masks =
             TAUDT_MSSTRUCT | TAUDT_CPPOBJ | TAUDT_UNALIGNED | TAUDT_VFTABLE | TAUDT_ALIGN_MASK;
         let others = NonZeroU16::new(value & !all_masks);

--- a/src/til.rs
+++ b/src/til.rs
@@ -150,14 +150,14 @@ impl Type {
         // IDBParam  in the `Root Node`
         let header = section::TILSectionHeader {
             format: 12,
-            flags: section::TILSectionFlag(0),
+            flags: section::TILSectionFlags(0),
             title: Vec::new(),
             description: Vec::new(),
-            id: 0,
+            compiler_id: 0,
             cm: 0,
-            size_enum: 0,
-            size_i: 4.try_into().unwrap(),
-            size_b: 1.try_into().unwrap(),
+            size_enum: None,
+            size_int: 4.try_into().unwrap(),
+            size_bool: 1.try_into().unwrap(),
             def_align: 0,
             size_long_double: None,
             size_short: 2.try_into().unwrap(),
@@ -371,7 +371,7 @@ impl Basic {
                     BT_INT32 => bytes(4),
                     BT_INT64 => bytes(8),
                     BT_INT128 => bytes(16),
-                    BT_INT => til.size_i,
+                    BT_INT => til.size_int,
                     _ => unreachable!(),
                 };
                 Ok(Self::Int { bytes, is_signed })
@@ -380,7 +380,7 @@ impl Basic {
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4805c4
             BT_BOOL => {
                 let bytes = match btmt {
-                    BTMT_DEFBOOL => til.size_b,
+                    BTMT_DEFBOOL => til.size_bool,
                     BTMT_BOOL1 => bytes(1),
                     BTMT_BOOL4 => bytes(4),
                     // TODO get the inf_is_64bit  field

--- a/src/til.rs
+++ b/src/til.rs
@@ -239,9 +239,11 @@ impl Type {
                     } else {
                         section.def_align as u64
                     };
-                    let align_diff = sum % align as u64;
-                    if align_diff != 0 {
-                        sum += align as u64 - align_diff;
+                    if align != 0 {
+                        let align_diff = sum % align as u64;
+                        if align_diff != 0 {
+                            sum += align as u64 - align_diff;
+                        }
                     }
                     sum += field_size;
                 }

--- a/src/til/array.rs
+++ b/src/til/array.rs
@@ -1,7 +1,6 @@
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
 use crate::til::{Type, TypeRaw, TAH};
-use anyhow::anyhow;
 
 #[derive(Clone, Debug)]
 pub struct Array {
@@ -14,16 +13,13 @@ impl Array {
     pub(crate) fn new(
         til: &TILSectionHeader,
         value: ArrayRaw,
-        fields: Option<Vec<Vec<u8>>>,
+        fields: &mut impl Iterator<Item = Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        if matches!(&fields, Some(f) if !f.is_empty()) {
-            return Err(anyhow!("fields in a Array"));
-        }
         Ok(Self {
             base: value.base,
             nelem: value.nelem,
             tah: value.tah,
-            elem_type: Type::new(til, *value.elem_type, None).map(Box::new)?,
+            elem_type: Type::new(til, *value.elem_type, fields).map(Box::new)?,
         })
     }
 }

--- a/src/til/array.rs
+++ b/src/til/array.rs
@@ -5,6 +5,7 @@ use crate::til::{Type, TypeRaw, TAH};
 #[derive(Clone, Debug)]
 pub struct Array {
     pub base: u8,
+    // TODO make this Option<NonZeroU16>?
     pub nelem: u16,
     pub tah: TAH,
     pub elem_type: Box<Type>,

--- a/src/til/array.rs
+++ b/src/til/array.rs
@@ -52,6 +52,7 @@ impl ArrayRaw {
                 (base, nelem.into())
             }
         };
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x48078e
         let tah = TAH::read(&mut *input)?;
         let elem_type = TypeRaw::read(&mut *input, header)?;
         Ok(ArrayRaw {

--- a/src/til/bitfield.rs
+++ b/src/til/bitfield.rs
@@ -10,7 +10,14 @@ pub struct Bitfield {
 
 impl Bitfield {
     pub(crate) fn read(input: &mut impl IdaGenericBufUnpack, metadata: u8) -> anyhow::Result<Self> {
-        let nbytes = 1 << (metadata >> 4);
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x472f3c print_til_type
+        let nbytes = match metadata {
+            super::flag::tf_complex::BTMT_BFLDI8 => 1,
+            super::flag::tf_complex::BTMT_BFLDI16 => 2,
+            super::flag::tf_complex::BTMT_BFLDI32 => 4,
+            super::flag::tf_complex::BTMT_BFLDI64 => 8,
+            _ => unreachable!(),
+        };
         let dt = input.read_dt()?;
         let width = dt >> 1;
         let unsigned = (dt & 1) > 0;

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -2,10 +2,8 @@ use std::num::NonZeroU8;
 
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
-use crate::til::{flag, Type, TypeAttribute, TypeRaw, SDACL, TAH};
+use crate::til::{flag, StructModifierRaw, Type, TypeAttribute, TypeRaw, SDACL, TAH};
 use anyhow::{anyhow, ensure};
-
-use super::r#struct::StructModifier;
 
 #[derive(Clone, Debug)]
 pub enum Enum {
@@ -15,10 +13,11 @@ pub enum Enum {
     },
     NonRef {
         output_format: EnumFormat,
-        modifiers: Vec<StructModifier>,
         members: Vec<(Option<Vec<u8>>, u64)>,
         groups: Vec<u16>,
         storage_size: Option<NonZeroU8>,
+        // TODO parse type attributes
+        //others: StructMemberRaw,
     },
 }
 impl Enum {
@@ -37,7 +36,6 @@ impl Enum {
             }),
             EnumRaw::NonRef {
                 output_format,
-                modifiers,
                 members,
                 groups,
                 storage_size,
@@ -48,7 +46,6 @@ impl Enum {
                 }
                 Ok(Enum::NonRef {
                     output_format,
-                    modifiers,
                     members: new_members,
                     groups,
                     storage_size,
@@ -66,7 +63,6 @@ pub(crate) enum EnumRaw {
     },
     NonRef {
         output_format: EnumFormat,
-        modifiers: Vec<StructModifier>,
         groups: Vec<u16>,
         members: Vec<u64>,
         storage_size: Option<NonZeroU8>,
@@ -92,7 +88,7 @@ impl EnumRaw {
         };
 
         let taenum_bits = TAH::read(&mut *input)?.0;
-        let modifiers = StructModifier::from_value(taenum_bits.0);
+        let _modifiers = StructModifierRaw::from_value(taenum_bits.0);
         // TODO parse ext attr
         let bte = input.read_u8()?;
         // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x452312 deserialize_enum
@@ -146,7 +142,6 @@ impl EnumRaw {
             .collect::<anyhow::Result<_>>()?;
         Ok(EnumRaw::NonRef {
             output_format,
-            modifiers,
             members,
             groups,
             storage_size,

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -75,7 +75,9 @@ impl EnumRaw {
         input: &mut impl IdaGenericBufUnpack,
         header: &TILSectionHeader,
     ) -> anyhow::Result<Self> {
+        use flag::tattr_enum::*;
         use flag::tf_enum::*;
+
         let Some(member_num) = input.read_dt_de()? else {
             // is ref
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
@@ -121,7 +123,7 @@ impl EnumRaw {
             _ => unreachable!(),
         };
 
-        let is_64 = (taenum_bits.0 & 0x20) != 0;
+        let is_64 = (taenum_bits.0 & TAENUM_64BIT) != 0;
         let mut cur: u64 = 0;
         let mut groups = vec![];
         let members = (0..member_num)

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -105,7 +105,7 @@ impl EnumRaw {
         // TODO enum size defaults to 4?
         let bytesize_final = bytesize
             .map(|x| x.get())
-            .or(header.size_enum.map(|x| x.get().into()))
+            .or(header.size_enum.map(|x| x.into()))
             .unwrap_or(4);
         let mask: u64 = if bytesize_final >= 16 {
             // is saturating valid?

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -93,11 +93,11 @@ impl EnumRaw {
         let bte = bincode::deserialize_from(&mut *input)?;
         let mut cur: u64 = 0;
         let emsize = bte & flag::tf_enum::BTE_SIZE_MASK;
-        let bytesize: u32 = match emsize {
-            0 if header.size_enum != 0 => header.size_enum.into(),
-            0 => return Err(anyhow!("BTE emsize is 0 without header")),
-            1..=4 => 1u32 << (emsize - 1),
-            5..=7 => return Err(anyhow!("BTE emsize with reserved values")),
+        let bytesize: u32 = match (emsize, header.size_enum) {
+            (0, Some(enum_size)) => enum_size.get().into(),
+            (0, None) => return Err(anyhow!("BTE emsize is 0 without header")),
+            (1..=4, _) => 1u32 << (emsize - 1),
+            (5..=7, _) => return Err(anyhow!("BTE emsize with reserved values")),
             _ => unreachable!(),
         };
 

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -2,71 +2,44 @@ use std::num::NonZeroU8;
 
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
-use crate::til::{flag, StructModifierRaw, Type, TypeAttribute, TypeRaw, SDACL, TAH};
+use crate::til::{flag, StructModifierRaw, TypeRaw, TypeVariantRaw, SDACL, TAH};
 use anyhow::{anyhow, ensure};
 
 #[derive(Clone, Debug)]
-pub enum Enum {
-    Ref {
-        ref_type: Box<Type>,
-        taenum_bits: TypeAttribute,
-    },
-    NonRef {
-        output_format: EnumFormat,
-        members: Vec<(Option<Vec<u8>>, u64)>,
-        groups: Vec<u16>,
-        storage_size: Option<NonZeroU8>,
-        // TODO parse type attributes
-        //others: StructMemberRaw,
-    },
+pub struct Enum {
+    pub output_format: EnumFormat,
+    pub members: Vec<(Option<Vec<u8>>, u64)>,
+    pub groups: Vec<u16>,
+    pub storage_size: Option<NonZeroU8>,
+    // TODO parse type attributes
+    //others: StructMemberRaw,
 }
 impl Enum {
     pub(crate) fn new(
-        til: &TILSectionHeader,
+        _til: &TILSectionHeader,
         value: EnumRaw,
         fields: &mut impl Iterator<Item = Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        match value {
-            EnumRaw::Ref {
-                ref_type,
-                taenum_bits,
-            } => Ok(Enum::Ref {
-                ref_type: Type::new(til, *ref_type, fields).map(Box::new)?,
-                taenum_bits,
-            }),
-            EnumRaw::NonRef {
-                output_format,
-                members,
-                groups,
-                storage_size,
-            } => {
-                let mut new_members = Vec::with_capacity(members.len());
-                for member in members {
-                    new_members.push((fields.next(), member));
-                }
-                Ok(Enum::NonRef {
-                    output_format,
-                    members: new_members,
-                    groups,
-                    storage_size,
-                })
-            }
-        }
+        let members = value
+            .members
+            .into_iter()
+            .map(|member| (fields.next(), member))
+            .collect();
+        Ok(Self {
+            output_format: value.output_format,
+            members,
+            groups: value.groups,
+            storage_size: value.storage_size,
+        })
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum EnumRaw {
-    Ref {
-        ref_type: Box<TypeRaw>,
-        taenum_bits: TypeAttribute,
-    },
-    NonRef {
-        output_format: EnumFormat,
-        groups: Vec<u16>,
-        members: Vec<u64>,
-        storage_size: Option<NonZeroU8>,
-    },
+pub(crate) struct EnumRaw {
+    output_format: EnumFormat,
+    groups: Vec<u16>,
+    members: Vec<u64>,
+    storage_size: Option<NonZeroU8>,
 }
 
 impl EnumRaw {
@@ -74,7 +47,7 @@ impl EnumRaw {
     pub(crate) fn read(
         input: &mut impl IdaGenericBufUnpack,
         header: &TILSectionHeader,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<TypeVariantRaw> {
         use flag::tattr_enum::*;
         use flag::tf_enum::*;
 
@@ -82,11 +55,8 @@ impl EnumRaw {
             // is ref
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
-            let taenum_bits = SDACL::read(&mut *input)?.0;
-            return Ok(EnumRaw::Ref {
-                ref_type: Box::new(ref_type),
-                taenum_bits,
-            });
+            let _taenum_bits = SDACL::read(&mut *input)?.0;
+            return Ok(TypeVariantRaw::EnumRef(Box::new(ref_type)));
         };
 
         let taenum_bits = TAH::read(&mut *input)?.0;
@@ -142,12 +112,12 @@ impl EnumRaw {
                 Ok(cur)
             })
             .collect::<anyhow::Result<_>>()?;
-        Ok(EnumRaw::NonRef {
+        Ok(TypeVariantRaw::Enum(EnumRaw {
             output_format,
             members,
             groups,
             storage_size,
-        })
+        }))
     }
 }
 

--- a/src/til/enum.rs
+++ b/src/til/enum.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU8;
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
 use crate::til::{associate_field_name_and_member, flag, Type, TypeAttribute, TypeRaw, SDACL, TAH};
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, ensure, Context};
 
 #[derive(Clone, Debug)]
 pub enum Enum {
@@ -12,11 +12,10 @@ pub enum Enum {
         taenum_bits: TypeAttribute,
     },
     NonRef {
-        group_sizes: Vec<u16>,
-        taenum_bits: TypeAttribute,
-        bte: u8,
+        output_format: EnumFormat,
         members: Vec<(Option<Vec<u8>>, u64)>,
-        bytesize: Option<NonZeroU8>,
+        groups: Vec<u16>,
+        storage_size: Option<NonZeroU8>,
     },
 }
 impl Enum {
@@ -39,21 +38,19 @@ impl Enum {
                 })
             }
             EnumRaw::NonRef {
-                group_sizes,
-                taenum_bits,
-                bte,
+                output_format,
                 members,
-                bytesize,
+                groups,
+                storage_size,
             } => {
                 let members = associate_field_name_and_member(fields, members)
                     .context("Enum")?
                     .collect();
                 Ok(Enum::NonRef {
-                    group_sizes,
-                    taenum_bits,
-                    bte,
+                    output_format,
                     members,
-                    bytesize,
+                    groups,
+                    storage_size,
                 })
             }
         }
@@ -67,20 +64,21 @@ pub(crate) enum EnumRaw {
         taenum_bits: TypeAttribute,
     },
     NonRef {
-        group_sizes: Vec<u16>,
-        taenum_bits: TypeAttribute,
-        bte: u8,
+        output_format: EnumFormat,
+        groups: Vec<u16>,
         members: Vec<u64>,
-        bytesize: Option<NonZeroU8>,
+        storage_size: Option<NonZeroU8>,
     },
 }
 
 impl EnumRaw {
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x473a08
     pub(crate) fn read(
         input: &mut impl IdaGenericBufUnpack,
         header: &TILSectionHeader,
     ) -> anyhow::Result<Self> {
-        let Some(n) = input.read_dt_de()? else {
+        use flag::tf_enum::*;
+        let Some(member_num) = input.read_dt_de()? else {
             // is ref
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
@@ -91,58 +89,71 @@ impl EnumRaw {
             });
         };
 
-        let taenum_bits = TAH::read(&mut *input)?.0;
-        let bte = bincode::deserialize_from(&mut *input)?;
-        let mut cur: u64 = 0;
-        let emsize = bte & flag::tf_enum::BTE_SIZE_MASK;
-        let bytesize: Option<NonZeroU8> = match emsize {
-            0 => None,
-            1..=4 => Some((1 << (emsize - 1)).try_into().unwrap()),
+        let _taenum_bits = TAH::read(&mut *input)?.0;
+        // TODO parse ext attr
+        let bte = input.read_u8()?;
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x452312 deserialize_enum
+        ensure!(
+            bte & BTE_ALWAYS != 0,
+            "Enum BTE missing the Always sub-field"
+        );
+        let storage_size: Option<NonZeroU8> = match bte & BTE_SIZE_MASK {
+            0 => header.size_enum,
+            emsize @ 1..=4 => Some((1 << (emsize - 1)).try_into().unwrap()),
+            // Allowed at InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4523c8 deserialize_enum
             5..=7 => return Err(anyhow!("BTE emsize with reserved values")),
             _ => unreachable!(),
         };
-
         // TODO enum size defaults to 4?
-        let bytesize_final = bytesize
-            .map(|x| x.get())
-            .or(header.size_enum.map(|x| x.into()))
-            .unwrap_or(4);
-        let mask: u64 = if bytesize_final >= 16 {
+        let storage_size_final = storage_size.map(NonZeroU8::get).unwrap_or(4);
+        let mask: u64 = if storage_size_final >= 16 {
             // is saturating valid?
             //u64::MAX
             return Err(anyhow!("Bytes size is too big"));
         } else {
-            u64::MAX >> (u64::BITS - (bytesize_final as u32 * 8))
+            u64::MAX >> (u64::BITS - (storage_size_final as u32 * 8))
         };
 
-        let mut group_sizes = vec![];
-        let mut members = vec![];
-        for _ in 0..n {
-            let lo: u64 = input.read_de()?.into();
-            let is_64 = (taenum_bits.0 & 0x0020) != 0;
-            let step = if is_64 {
-                let hi: u64 = input.read_de()?.into();
-                (lo | (hi << 32)) & mask
-            } else {
-                lo & mask
-            };
-            // TODO: subarrays
-            // https://www.hex-rays.com/products/ida/support/sdkdoc/group__tf__enum.html#ga9ae7aa54dbc597ec17cbb17555306a02
-            if (bte & flag::tf_enum::BTE_BITFIELD) != 0 {
-                let group_size = input.read_dt()?;
-                group_sizes.push(group_size);
-            }
-            // TODO check is this is wrapping by default
-            let next_step = cur.wrapping_add(step);
-            cur = next_step;
-            members.push(cur);
-        }
+        let output_format = match bte & BTE_OUT_MASK {
+            BTE_HEX => EnumFormat::Hex,
+            BTE_CHAR => EnumFormat::Char,
+            BTE_SDEC => EnumFormat::SignedDecimal,
+            BTE_UDEC => EnumFormat::UnsignedDecimal,
+            _ => unreachable!(),
+        };
+
+        let is_64 = (_taenum_bits.0 & 0x20) != 0;
+        let mut cur: u64 = 0;
+        let mut groups = vec![];
+        let members = (0..member_num)
+            .map(|_member_idx| {
+                let mut step: u64 = input.read_de()?.into();
+                if is_64 {
+                    let hi: u64 = input.read_de()?.into();
+                    step |= hi << 32;
+                }
+                if bte & BTE_BITFIELD != 0 {
+                    let group_size = input.read_dt()?;
+                    groups.push(group_size);
+                }
+                // TODO check is this is wrapping by default
+                cur = cur.wrapping_add(step & mask);
+                Ok(cur)
+            })
+            .collect::<anyhow::Result<_>>()?;
         Ok(EnumRaw::NonRef {
-            group_sizes,
-            taenum_bits,
-            bte,
+            output_format,
             members,
-            bytesize,
+            groups,
+            storage_size,
         })
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum EnumFormat {
+    Char,
+    Hex,
+    SignedDecimal,
+    UnsignedDecimal,
 }

--- a/src/til/flag.rs
+++ b/src/til/flag.rs
@@ -413,20 +413,20 @@ pub mod tf_shortcuts {
 }
 
 /// pack buckets using zip
-pub const TIL_ZIP: u32 = 0x0001;
+pub const TIL_ZIP: u16 = 0x0001;
 /// til has macro table
-pub const TIL_MAC: u32 = 0x0002;
+pub const TIL_MAC: u16 = 0x0002;
 /// extended sizeof info (short, long, longlong)
-pub const TIL_ESI: u32 = 0x0004;
+pub const TIL_ESI: u16 = 0x0004;
 /// universal til for any compiler
-pub const TIL_UNI: u32 = 0x0008;
+pub const TIL_UNI: u16 = 0x0008;
 /// type ordinal numbers are present
-pub const TIL_ORD: u32 = 0x0010;
+pub const TIL_ORD: u16 = 0x0010;
 /// type aliases are present (this bit is used only on the disk)
-pub const TIL_ALI: u32 = 0x0020;
+pub const TIL_ALI: u16 = 0x0020;
 /// til has been modified, should be saved
-pub const TIL_MOD: u32 = 0x0040;
+pub const TIL_MOD: u16 = 0x0040;
 /// til has extra streams
-pub const TIL_STM: u32 = 0x0080;
+pub const TIL_STM: u16 = 0x0080;
 /// sizeof(long double)
-pub const TIL_SLD: u32 = 0x0100;
+pub const TIL_SLD: u16 = 0x0100;

--- a/src/til/flag.rs
+++ b/src/til/flag.rs
@@ -208,14 +208,14 @@ pub mod tf_func {
     /// ```
     pub const BT_FUNC: TypeT = 0x0C;
 
-    ///< call method - default for model or unknown
+    /// call method - default for model or unknown
     pub const BTMT_DEFCALL: TypeT = 0x00;
-    ///< function returns by retn
+    /// function returns by retn
     pub const BTMT_NEARCALL: TypeT = 0x10;
-    ///< function returns by retf
+    /// function returns by retf
     pub const BTMT_FARCALL: TypeT = 0x20;
-    ///< function returns by iret
-    ///< in this case cc MUST be 'unknown'
+    /// function returns by iret
+    /// in this case cc MUST be 'unknown'
     pub const BTMT_INTCALL: TypeT = 0x30;
     /// __noreturn
     pub const BFA_NORET: TypeT = 0x01;

--- a/src/til/flag.rs
+++ b/src/til/flag.rs
@@ -6,7 +6,7 @@ type BteT = u8;
 type TilT = u16;
 /// TypeAtt Type flags
 type TattrT = u16;
-type CmT = u16;
+type CmT = u8;
 
 /// multi-use
 pub const RESERVED_BYTE: TypeT = 0xFF;
@@ -565,16 +565,12 @@ pub mod cm {
         pub const CM_MASK: CmT = 0x03;
         /// unknown
         pub const CM_UNKNOWN: CmT = 0x00;
-
         /// if sizeof(int)<=2: near 1 byte, far 2 bytes
         pub const CM_N8_F16: CmT = 0x01;
-
         /// if sizeof(int)>2: near 8 bytes, far 8 bytes
         pub const CM_N64: CmT = 0x01;
-
         /// near 2 bytes, far 4 bytes
         pub const CM_N16_F32: CmT = 0x02;
-
         /// near 4 bytes, far 6 bytes
         pub const CM_N32_F48: CmT = 0x03;
     }
@@ -586,10 +582,8 @@ pub mod cm {
         pub const CM_M_NN: CmT = 0x00;
         /// large:   code=far, data=far
         pub const CM_M_FF: CmT = 0x04;
-
         /// compact: code=near, data=far
         pub const CM_M_NF: CmT = 0x08;
-
         /// medium:  code=far, data=near
         pub const CM_M_FN: CmT = 0x0C;
     }
@@ -600,27 +594,20 @@ pub mod cm {
         pub const CM_CC_MASK: CmT = 0xF0;
         /// this value is invalid
         pub const CM_CC_INVALID: CmT = 0x00;
-
         /// unknown calling convention
         pub const CM_CC_UNKNOWN: CmT = 0x10;
-
         /// function without arguments
         /// if has other cc and argnum == 0,
         /// represent as f() - unknown list
         pub const CM_CC_VOIDARG: CmT = 0x20;
-
         /// stack
         pub const CM_CC_CDECL: CmT = 0x30;
-
         /// cdecl + ellipsis
         pub const CM_CC_ELLIPSIS: CmT = 0x40;
-
         /// stack, purged
         pub const CM_CC_STDCALL: CmT = 0x50;
-
         /// stack, purged, reverse order of args
         pub const CM_CC_PASCAL: CmT = 0x60;
-
         /// stack, purged (x86), first args are in regs (compiler-dependent)
         pub const CM_CC_FASTCALL: CmT = 0x70;
         /// stack, purged (x86), first arg is in reg (compiler-dependent)
@@ -632,17 +619,13 @@ pub mod cm {
         /// present real cm_t byte. if n == BFA_FUNC_MARKER,
         /// the next byte is the function attribute byte.
         pub const CM_CC_SPOILED: CmT = 0xA0;
-
         /// (Go) arguments and return value in stack
         pub const CM_CC_GOLANG: CmT = 0xB0;
-
         pub const CM_CC_RESERVE3: CmT = 0xC0;
         /// ::CM_CC_SPECIAL with ellipsis
         pub const CM_CC_SPECIALE: CmT = 0xD0;
-
         /// Equal to ::CM_CC_SPECIAL, but with purged stack
         pub const CM_CC_SPECIALP: CmT = 0xE0;
-
         /// usercall: locations of all arguments
         /// and the return value are explicitly specified
         pub const CM_CC_SPECIAL: CmT = 0xF0;

--- a/src/til/function.rs
+++ b/src/til/function.rs
@@ -159,14 +159,15 @@ impl ArgLoc {
                 }
             }
         } else {
+            use super::flag::tf_func::argloc::*;
             let typ = input.read_dt()?;
-            match typ & 0xF {
-                0 => Ok(Self::None),
-                1 => {
+            match (typ & 0xF) as u8 {
+                ALOC_NONE => Ok(Self::None),
+                ALOC_STACK => {
                     let sval = input.read_de()?;
                     Ok(Self::Stack(sval))
                 }
-                2 => {
+                ALOC_DIST => {
                     let n = (typ >> 5) & 0x7;
                     let dist: Vec<_> = (0..n)
                         .map(|_| {
@@ -178,27 +179,26 @@ impl ArgLoc {
                         .collect::<anyhow::Result<_>>()?;
                     Ok(Self::Dist(dist))
                 }
-                3 => {
+                ALOC_REG1 => {
                     let reg_info = input.read_dt()?;
                     // TODO read other dt?
                     Ok(Self::Reg1(reg_info.into()))
                 }
-                4 => {
+                ALOC_REG2 => {
                     let reg_info = input.read_dt()?;
                     // TODO read other dt?
                     Ok(Self::Reg2(reg_info.into()))
                 }
-                5 => {
+                ALOC_RREL => {
                     let reg = input.read_dt()?;
                     let off = input.read_de()?;
                     Ok(Self::RRel { reg, off })
                 }
-                6 => {
+                ALOC_STATIC => {
                     let sval = input.read_de()?;
                     Ok(Self::Static(sval))
                 }
-                0x7..=0xF => todo!("Custom implementation for ArgLoc"),
-                _ => unreachable!(),
+                ALOC_CUSTOM.. => Err(anyhow!("Custom implementation for ArgLoc")),
             }
         }
     }

--- a/src/til/function.rs
+++ b/src/til/function.rs
@@ -3,6 +3,8 @@ use crate::til::section::TILSectionHeader;
 use crate::til::{associate_field_name_and_member, Basic, Type, TypeMetadata, TypeRaw, TAH};
 use anyhow::{ensure, Context};
 
+use super::TypeVariantRaw;
+
 #[derive(Debug, Clone)]
 pub struct Function {
     pub ret: Box<Type>,
@@ -93,7 +95,7 @@ impl FunctionRaw {
         let ret = TypeRaw::read(&mut *input, header)?;
         // TODO double check documentation for [flag::tf_func::BT_FUN]
         let have_retloc = cc.get_calling_convention().is_special_pe()
-            && !matches!(&ret, TypeRaw::Basic(Basic::Void));
+            && !matches!(&ret.variant, TypeVariantRaw::Basic(Basic::Void));
         let retloc = have_retloc.then(|| ArgLoc::read(&mut *input)).transpose()?;
         if cc.get_calling_convention().is_void_arg() {
             return Ok(Self {

--- a/src/til/function.rs
+++ b/src/til/function.rs
@@ -130,13 +130,14 @@ impl FunctionRaw {
         let cc = CallingConvention::from_cm_raw(cc)
             .ok_or_else(|| anyhow!("Invalid Function Calling Convention"))?;
 
+        // TODO investigate why this don't hold true
         // function returns by iret (BTMT_INTCALL) in this case cc MUST be 'unknown'
-        if method == Some(CallMethod::Int) {
-            ensure!(
-                cc == CallingConvention::Unknown,
-                "Invalid CC in function with CallMethod Int"
-            );
-        }
+        //if method == Some(CallMethod::Int) {
+        //    ensure!(
+        //        cc == CallingConvention::Unknown,
+        //        "Invalid CC in function with CallMethod Int"
+        //    );
+        //}
 
         // consume the flags and verify if a unknown value is present
         // TODO find those in flags

--- a/src/til/function.rs
+++ b/src/til/function.rs
@@ -75,9 +75,13 @@ impl FunctionRaw {
         header: &TILSectionHeader,
         metadata: u8,
     ) -> anyhow::Result<Self> {
-        // TODO failing to parse `void __fastcall stringstream__basic_ios__sub_180007CF0_Destructor(basic_ios *__shifted(stringstream,0x94) a1);`
-        // from https://github.com/Vector35/idb-rs/issues/8
-
+        //match metadata {
+        //    super::flag::tf_func::BTMT_DEFCALL => todo!(),
+        //    super::flag::tf_func::BTMT_NEARCALL => todo!(),
+        //    super::flag::tf_func::BTMT_FARCALL => todo!(),
+        //    super::flag::tf_func::BTMT_INTCALL => todo!(),
+        //    _ => unreachable!(),
+        //}
         // TODO what is that?
         let mut flags = metadata << 2;
 

--- a/src/til/pointer.rs
+++ b/src/til/pointer.rs
@@ -89,6 +89,7 @@ impl PointerRaw {
 #[derive(Debug, Clone)]
 pub(crate) enum PointerTypeRaw {
     Closure(Box<TypeRaw>),
+    // ptr size: {0}
     PointerBased(u8),
     Default,
     Far,

--- a/src/til/pointer.rs
+++ b/src/til/pointer.rs
@@ -1,5 +1,3 @@
-use anyhow::ensure;
-
 use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
 use crate::til::{Type, TypeRaw, TAH};
@@ -89,6 +87,7 @@ impl PointerRaw {
         }
 
         // TODO find the flag for this
+        // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x459bc6 print_til_type_att
         let modifier = match tah.0 .0 & 0x60 {
             0x00 => None,
             0x20 => Some(PointerModifier::Ptr32),

--- a/src/til/pointer.rs
+++ b/src/til/pointer.rs
@@ -13,9 +13,10 @@ impl Pointer {
     pub(crate) fn new(
         til: &TILSectionHeader,
         raw: PointerRaw,
-        fields: Option<Vec<Vec<u8>>>,
+        fields: &mut impl Iterator<Item = Vec<u8>>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
+            // TODO forward fields to closure?
             closure: PointerType::new(til, raw.closure)?,
             modifier: raw.modifier,
             typ: Type::new(til, *raw.typ, fields).map(Box::new)?,
@@ -35,7 +36,13 @@ pub enum PointerType {
 impl PointerType {
     fn new(til: &TILSectionHeader, raw: PointerTypeRaw) -> anyhow::Result<Self> {
         match raw {
-            PointerTypeRaw::Closure(c) => Type::new(til, *c, None).map(Box::new).map(Self::Closure),
+            PointerTypeRaw::Closure(c) => {
+                // TODO subtype get the fields?
+                let mut sub_fields = vec![].into_iter();
+                Type::new(til, *c, &mut sub_fields)
+                    .map(Box::new)
+                    .map(Self::Closure)
+            }
             PointerTypeRaw::PointerBased(p) => Ok(Self::PointerBased(p)),
             PointerTypeRaw::Default => Ok(Self::Default),
             PointerTypeRaw::Far => Ok(Self::Far),

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -126,7 +126,7 @@ impl TILSection {
             format: header.format,
             title: header.title,
             flags: header.flags,
-            dependency: (header.description.len() != 0).then_some(header.description),
+            dependency: header.description.is_empty().then_some(header.description),
             compiler_id: Compiler::from_value(header.compiler_id),
             cm: header.cm,
             def_align: header.def_align,

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -510,7 +510,7 @@ impl TILSection {
         }
         let mut input = input.take(len.into());
         let type_info = (0..ndefs)
-            .map(|_| TILTypeInfo::read(&mut input, header))
+            .map(|i| TILTypeInfo::read(&mut input, header, i == ndefs - 1))
             .collect::<Result<_>>()?;
         ensure!(
             input.limit() == 0,

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufReader, Read, Write};
 use std::num::NonZeroU8;
 
+use super::function::CallingConvention;
+
 // TODO migrate this to flags
 pub const TIL_SECTION_MAGIC: &[u8; 6] = b"IDATIL";
 
@@ -656,44 +658,5 @@ impl TILSection {
             "TypeBucket compressed data is smaller then expected"
         );
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum CallingConvention {
-    CCInvalid = 0x0,
-    Voidarg = 0x2,
-    Cdecl = 0x3,
-    Ellipsis = 0x4,
-    Stdcall = 0x5,
-    Pascal = 0x6,
-    Fastcall = 0x7,
-    Thiscall = 0x8,
-    Swift = 0x9,
-    Golang = 0xb,
-    Userpurge = 0xe,
-    Uservars = 0xd,
-    Usercall = 0xf,
-}
-
-impl CallingConvention {
-    fn from_cm_raw(cm: u8) -> Option<Self> {
-        Some(match cm & 0xf0 >> 4 {
-            0x1 | 0xa | 0xc => return None,
-            0x0 => Self::CCInvalid,
-            0x2 => Self::Voidarg,
-            0x3 => Self::Cdecl,
-            0x4 => Self::Ellipsis,
-            0x5 => Self::Stdcall,
-            0x6 => Self::Pascal,
-            0x7 => Self::Fastcall,
-            0x8 => Self::Thiscall,
-            0x9 => Self::Swift,
-            0xb => Self::Golang,
-            0xe => Self::Userpurge,
-            0xd => Self::Uservars,
-            0xf => Self::Usercall,
-            0x10.. => unreachable!(),
-        })
     }
 }

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -362,6 +362,10 @@ impl TILSection {
         Ok(())
     }
 
+    pub fn get_name(&self, name: &[u8]) -> Option<&TILTypeInfo> {
+        self.types.iter().find(|ty| ty.name.as_slice() == name)
+    }
+
     pub fn get_ord(&self, id0_ord: Id0TilOrd) -> Option<&TILTypeInfo> {
         // first search the ordinal alias
         if let Some(ordinals) = &self.type_ordinal_alias {

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -440,7 +440,7 @@ pub struct TILSectionFlags(pub(crate) u16);
 impl TILSectionFlags {
     fn new(value: u32) -> Result<Self> {
         ensure!(
-            value < (flag::TIL_SLD as u32) << 1,
+            value < (flag::til::TIL_SLD as u32) << 1,
             "Unknown flag values for TILSectionFlags"
         );
         Ok(Self(value as u16))
@@ -451,45 +451,45 @@ impl TILSectionFlags {
     }
 
     pub fn is_zip(&self) -> bool {
-        self.0 & flag::TIL_ZIP != 0
+        self.0 & flag::til::TIL_ZIP != 0
     }
     pub fn set_zip(&mut self, value: bool) {
         if value {
-            self.0 |= flag::TIL_ZIP
+            self.0 |= flag::til::TIL_ZIP
         } else {
-            self.0 &= !flag::TIL_ZIP
+            self.0 &= !flag::til::TIL_ZIP
         }
     }
     pub fn has_macro_table(&self) -> bool {
-        self.0 & flag::TIL_MAC != 0
+        self.0 & flag::til::TIL_MAC != 0
     }
     /// extended sizeof info (short, long, longlong)
     pub fn have_extended_sizeof_info(&self) -> bool {
-        self.0 & flag::TIL_ESI != 0
+        self.0 & flag::til::TIL_ESI != 0
     }
     /// universal til for any compiler
     pub fn is_universal(&self) -> bool {
-        self.0 & flag::TIL_UNI != 0
+        self.0 & flag::til::TIL_UNI != 0
     }
     /// type ordinal numbers are present
     pub fn has_ordinal(&self) -> bool {
-        self.0 & flag::TIL_ORD != 0
+        self.0 & flag::til::TIL_ORD != 0
     }
     /// type aliases are present
     pub fn has_type_aliases(&self) -> bool {
-        self.0 & flag::TIL_ALI != 0
+        self.0 & flag::til::TIL_ALI != 0
     }
     /// til has been modified, should be saved
     pub fn is_mod(&self) -> bool {
-        self.0 & flag::TIL_MOD != 0
+        self.0 & flag::til::TIL_MOD != 0
     }
     /// til has extra streams
     pub fn has_extra_stream(&self) -> bool {
-        self.0 & flag::TIL_STM != 0
+        self.0 & flag::til::TIL_STM != 0
     }
     /// sizeof(long double)
     pub fn has_size_long_double(&self) -> bool {
-        self.0 & flag::TIL_SLD != 0
+        self.0 & flag::til::TIL_SLD != 0
     }
 }
 

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -535,7 +535,9 @@ impl TILSection {
                     ));
                 }
                 let inner_type = self.get_type_by_idx(inner_type_idx);
-                self.inner_type_size_bytes(&inner_type.tinfo, map)?
+                let result = self.inner_type_size_bytes(&inner_type.tinfo, map)?;
+                map.remove(&inner_type_idx);
+                result
             }
             TypeVariant::Typedef(Typedef::Ordinal(ord)) => {
                 let inner_type_idx = self
@@ -547,7 +549,9 @@ impl TILSection {
                     ));
                 }
                 let inner_type = self.get_type_by_idx(inner_type_idx);
-                self.inner_type_size_bytes(&inner_type.tinfo, map)?
+                let result = self.inner_type_size_bytes(&inner_type.tinfo, map)?;
+                map.remove(&inner_type_idx);
+                result
             }
             TypeVariant::StructRef(ref_type)
             | TypeVariant::UnionRef(ref_type)

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -13,12 +13,12 @@ pub const TIL_SECTION_MAGIC: &[u8; 6] = b"IDATIL";
 #[derive(Debug, Clone)]
 pub struct TILSection {
     pub format: u32,
-    // TODO is title and description inverted?
     /// short file name (without path and extension)
     pub title: Vec<u8>,
     pub flags: TILSectionFlags,
-    /// human readable til description
-    pub description: Vec<u8>,
+    // TODO unclear what exacly dependency is for
+    /// module required
+    pub dependency: Option<Vec<u8>>,
     /// the compiler used to generated types
     pub compiler_id: Compiler,
     /// information about the target compiler
@@ -126,7 +126,7 @@ impl TILSection {
             format: header.format,
             title: header.title,
             flags: header.flags,
-            description: header.description,
+            dependency: (header.description.len() != 0).then_some(header.description),
             compiler_id: Compiler::from_value(header.compiler_id),
             cm: header.cm,
             def_align: header.def_align,

--- a/src/til/section.rs
+++ b/src/til/section.rs
@@ -136,7 +136,7 @@ impl TILSection {
         let _ali = header.flags.has_type_aliases();
         let _stm = header.flags.has_extra_stream();
 
-        let cc = CallingConvention::from_cm_raw(header.cm);
+        let cc = CallingConvention::from_cm_raw(header.cm)?;
         let cn = CCPtrSize::from_cm_raw(header.cm, header.size_int);
         let cm = CCModel::from_cm_raw(header.cm);
 

--- a/src/til/union.rs
+++ b/src/til/union.rs
@@ -4,21 +4,15 @@ use crate::ida_reader::IdaGenericBufUnpack;
 use crate::til::section::TILSectionHeader;
 use crate::til::{Type, TypeRaw, SDACL};
 
-use super::StructModifierRaw;
+use super::{StructModifierRaw, TypeVariantRaw};
 
 #[derive(Clone, Debug)]
-pub enum Union {
-    Ref {
-        ref_type: Box<Type>,
-        taudt_bits: SDACL,
-    },
-    NonRef {
-        effective_alignment: u16,
-        alignment: Option<NonZeroU8>,
-        members: Vec<(Option<Vec<u8>>, Type)>,
-        // TODO parse type attributes
-        //others: StructMemberRaw,
-    },
+pub struct Union {
+    pub effective_alignment: u16,
+    pub alignment: Option<NonZeroU8>,
+    pub members: Vec<(Option<Vec<u8>>, Type)>,
+    // TODO parse type attributes
+    //others: StructMemberRaw,
 }
 impl Union {
     pub(crate) fn new(
@@ -26,64 +20,43 @@ impl Union {
         value: UnionRaw,
         fields: &mut impl Iterator<Item = Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        match value {
-            UnionRaw::Ref {
-                ref_type,
-                taudt_bits,
-            } => Ok(Union::Ref {
-                ref_type: Type::new(til, *ref_type, fields).map(Box::new)?,
-                taudt_bits,
-            }),
-            UnionRaw::NonRef {
-                effective_alignment,
-                alignment,
-                members,
-            } => {
-                let mut new_members = Vec::with_capacity(members.len());
-                for member in members {
-                    let field = fields.next();
-                    let new_member = Type::new(til, member, &mut *fields)?;
-                    new_members.push((field, new_member));
-                }
-                Ok(Union::NonRef {
-                    effective_alignment,
-                    alignment,
-                    members: new_members,
-                })
-            }
-        }
+        let members = value
+            .members
+            .into_iter()
+            .map(|member| {
+                let field_name = fields.next();
+                let new_member = Type::new(til, member, &mut *fields)?;
+                Ok((field_name, new_member))
+            })
+            .collect::<anyhow::Result<_>>()?;
+        Ok(Union {
+            effective_alignment: value.effective_alignment,
+            alignment: value.alignment,
+            members,
+        })
     }
 }
 
 // TODO struct and union are basically identical, the diff is that member in union don't have SDACL,
 // merge both
 #[derive(Clone, Debug)]
-pub(crate) enum UnionRaw {
-    Ref {
-        ref_type: Box<TypeRaw>,
-        taudt_bits: SDACL,
-    },
-    NonRef {
-        effective_alignment: u16,
-        alignment: Option<NonZeroU8>,
-        members: Vec<TypeRaw>,
-    },
+pub(crate) struct UnionRaw {
+    effective_alignment: u16,
+    alignment: Option<NonZeroU8>,
+    members: Vec<TypeRaw>,
 }
 
 impl UnionRaw {
     pub fn read(
         input: &mut impl IdaGenericBufUnpack,
         header: &TILSectionHeader,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<TypeVariantRaw> {
         let Some(n) = input.read_dt_de()? else {
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4803b4
             // is ref
             let ref_type = TypeRaw::read_ref(&mut *input, header)?;
-            let taudt_bits = SDACL::read(&mut *input)?;
-            return Ok(Self::Ref {
-                ref_type: Box::new(ref_type),
-                taudt_bits,
-            });
+            let _taudt_bits = SDACL::read(&mut *input)?;
+            return Ok(TypeVariantRaw::UnionRef(Box::new(ref_type)));
         };
 
         // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x4808f9
@@ -97,10 +70,10 @@ impl UnionRaw {
         let members = (0..mem_cnt)
             .map(|_| TypeRaw::read(&mut *input, header))
             .collect::<anyhow::Result<_, _>>()?;
-        Ok(Self::NonRef {
+        Ok(TypeVariantRaw::Union(Self {
             effective_alignment,
             alignment,
             members,
-        })
+        }))
     }
 }

--- a/src/tools/dump_dirtree_funcs.rs
+++ b/src/tools/dump_dirtree_funcs.rs
@@ -27,7 +27,7 @@ pub fn print_function(id0: &ID0Section, address: Id0Address) -> Result<()> {
             }
             idb_rs::id0::AddressInfo::TilType(addr_ty) => {
                 ensure!(
-                    matches!(&addr_ty, idb_rs::til::Type::Function(_)),
+                    matches!(&addr_ty.type_variant, idb_rs::til::TypeVariant::Function(_)),
                     "Type for function at {address:#?} is invalid"
                 );
                 if let Some(_old) = ty.replace(addr_ty) {

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -29,13 +29,15 @@ pub fn dump_til(args: &Args) -> Result<()> {
     let TILSection {
         format,
         title,
+        flags: _,
         description,
-        id,
+        compiler_id,
         cm,
         def_align,
         type_ordinal_alias,
-        size_i,
-        size_b,
+        size_int,
+        size_enum,
+        size_bool,
         size_short,
         size_long,
         size_long_long,
@@ -49,11 +51,12 @@ pub fn dump_til(args: &Args) -> Result<()> {
     println!("format: {format}");
     println!("title: {}", String::from_utf8_lossy(&title));
     println!("description: {}", String::from_utf8_lossy(&description));
-    println!("id: {id}");
+    println!("id: {compiler_id:?}");
     println!("cm: {cm}");
     println!("def_align: {def_align}");
-    println!("size_i: {size_i}");
-    println!("size_b: {size_b}");
+    println!("size_int: {size_int}");
+    println!("size_bool: {size_bool}");
+    println!("size_enum: {size_enum:?}");
     println!("is_universal: {is_universal}");
     if let Some(type_ordinal_numbers) = type_ordinal_alias {
         println!("type_ordinal_numbers: {type_ordinal_numbers:?}");

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -38,15 +38,13 @@ pub fn dump_til(args: &Args) -> Result<()> {
         size_int,
         size_enum,
         size_bool,
-        size_short,
-        size_long,
-        size_long_long,
+        extended_sizeof_info: _,
         size_long_double,
         is_universal,
         symbols,
         types,
         macros,
-    } = til;
+    } = &til;
     // write the header info
     println!("format: {format}");
     println!("title: {}", String::from_utf8_lossy(&title));
@@ -64,9 +62,9 @@ pub fn dump_til(args: &Args) -> Result<()> {
     if let Some(size_long_double) = size_long_double {
         println!("size_long_double: {size_long_double}");
     }
-    println!("size short: {size_short}");
-    println!("size long: {size_long}");
-    println!("size long_long: {size_long_long}");
+    println!("size short: {}", til.sizeof_short());
+    println!("size long: {}", til.sizeof_long());
+    println!("size long_long: {}", til.sizeof_long_long());
 
     // TODO implement Display for TILTypeInfo
     println!("types:");

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -32,7 +32,9 @@ pub fn dump_til(args: &Args) -> Result<()> {
         flags: _,
         dependency,
         compiler_id,
+        cc,
         cm,
+        cn,
         def_align,
         type_ordinal_alias,
         size_int,
@@ -52,7 +54,9 @@ pub fn dump_til(args: &Args) -> Result<()> {
         println!("dependency: {}", String::from_utf8_lossy(dependency));
     }
     println!("id: {compiler_id:?}");
-    println!("cm: {cm}");
+    println!("cc: {cc:?}");
+    println!("cm: {cm:?}");
+    println!("cn: {cn:?}");
     println!("def_align: {}", def_align.map(|x| x.get()).unwrap_or(0));
     println!("size_int: {size_int}");
     println!("size_bool: {size_bool}");

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -47,7 +47,7 @@ pub fn dump_til(args: &Args) -> Result<()> {
     } = &til;
     // write the header info
     println!("format: {format}");
-    println!("title: {}", String::from_utf8_lossy(&title));
+    println!("title: {}", String::from_utf8_lossy(title));
     if let Some(dependency) = dependency {
         println!("dependency: {}", String::from_utf8_lossy(dependency));
     }
@@ -86,7 +86,7 @@ pub fn dump_til(args: &Args) -> Result<()> {
             param_num: _,
         } in macros
         {
-            let name = String::from_utf8_lossy(&name);
+            let name = String::from_utf8_lossy(name);
             let value: String = value
                 .iter()
                 .map(|c| match c {

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -30,7 +30,7 @@ pub fn dump_til(args: &Args) -> Result<()> {
         format,
         title,
         flags: _,
-        dependency: description,
+        dependency,
         compiler_id,
         cm,
         def_align,
@@ -48,7 +48,9 @@ pub fn dump_til(args: &Args) -> Result<()> {
     // write the header info
     println!("format: {format}");
     println!("title: {}", String::from_utf8_lossy(&title));
-    println!("description: {}", String::from_utf8_lossy(&description));
+    if let Some(dependency) = dependency {
+        println!("dependency: {}", String::from_utf8_lossy(dependency));
+    }
     println!("id: {compiler_id:?}");
     println!("cm: {cm}");
     println!("def_align: {def_align}");

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -80,9 +80,20 @@ pub fn dump_til(args: &Args) -> Result<()> {
 
     if let Some(macros) = macros {
         println!("\n------------------------------macros------------------------------");
-        for TILMacro { name, value } in macros {
+        for TILMacro {
+            name,
+            value,
+            param_num: _,
+        } in macros
+        {
             let name = String::from_utf8_lossy(&name);
-            let value = String::from_utf8_lossy(&value);
+            let value: String = value
+                .iter()
+                .map(|c| match c {
+                    idb_rs::til::TILMacroValue::Char(c) => format!("{}", *c as char),
+                    idb_rs::til::TILMacroValue::Param(param) => format!("{{P{}}}", *param),
+                })
+                .collect();
             println!("------------------------------`{name}`------------------------------");
             println!("{value}");
             println!("------------------------------`{name}`-end------------------------------",);

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -30,7 +30,7 @@ pub fn dump_til(args: &Args) -> Result<()> {
         format,
         title,
         flags: _,
-        description,
+        dependency: description,
         compiler_id,
         cm,
         def_align,

--- a/src/tools/dump_til.rs
+++ b/src/tools/dump_til.rs
@@ -53,7 +53,7 @@ pub fn dump_til(args: &Args) -> Result<()> {
     }
     println!("id: {compiler_id:?}");
     println!("cm: {cm}");
-    println!("def_align: {def_align}");
+    println!("def_align: {}", def_align.map(|x| x.get()).unwrap_or(0));
     println!("size_int: {size_int}");
     println!("size_bool: {size_bool}");
     println!("size_enum: {size_enum:?}");

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -593,7 +593,6 @@ fn print_til_type_len(
 fn calling_convention_to_str(cc: CallingConvention) -> &'static str {
     use idb_rs::til::function::CallingConvention::*;
     match cc {
-        Invalid => "__ccinvalid",
         Unknown => "__unknown",
         Voidarg => "__voidarg",
         Cdecl => "__cdecl",

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -411,9 +411,24 @@ fn print_til_type(
                 print_pointer_space,
                 print_type_prefix,
             ),
-            Struct::NonRef { members, .. } => {
+            Struct::NonRef {
+                members, modifiers, ..
+            } => {
                 let name = name.unwrap_or("");
-                write!(fmt, "struct {name} {{")?;
+                write!(fmt, "struct ")?;
+                for modifier in modifiers {
+                    match modifier {
+                        idb_rs::til::r#struct::StructModifier::Unaligned => {
+                            write!(fmt, "__unaligned ")?
+                        }
+                        idb_rs::til::r#struct::StructModifier::Attribute => {
+                            write!(fmt, "__attribute__((msstruct)) ")?
+                        }
+                        idb_rs::til::r#struct::StructModifier::CppObj => write!(fmt, "__cppobj ")?,
+                        idb_rs::til::r#struct::StructModifier::Unknown => write!(fmt, "__other ")?,
+                    }
+                }
+                write!(fmt, "{name} {{")?;
                 for member in members {
                     let name = member
                         .name

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -267,12 +267,6 @@ fn print_til_type_root(
         | TypeVariant::Enum(Enum::NonRef { .. }) => {}
         _ => write!(fmt, "typedef ")?,
     }
-    if til_type.is_volatile {
-        write!(fmt, "volatile ")?;
-    }
-    if til_type.is_const {
-        write!(fmt, "const ")?;
-    }
     print_til_type(fmt, section, name, til_type, true, true)
 }
 
@@ -284,6 +278,12 @@ fn print_til_type(
     print_pointer_space: bool,
     print_type_prefix: bool,
 ) -> std::io::Result<()> {
+    if til_type.is_volatile {
+        write!(fmt, "volatile ")?;
+    }
+    if til_type.is_const {
+        write!(fmt, "const ")?;
+    }
     let name_helper = name.map(|name| format!(" {name}")).unwrap_or_default();
     const fn signed_name(is_signed: Option<bool>) -> &'static str {
         match is_signed {

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -498,7 +498,7 @@ fn print_til_type_function(
         }
         write!(fmt, "...")?;
     }
-    write!(fmt, " )")
+    write!(fmt, ")")
 }
 
 fn print_til_type_array(

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -341,6 +341,7 @@ fn print_til_type(
         Type::Basic(Basic::BoolSized { bytes }) => write!(fmt, "bool{bytes}{name_helper}"),
         Type::Pointer(pointer) => {
             if let Type::Function(inner_fun) = &*pointer.typ {
+                // How to handle modifier here?
                 let name = format!("(*{})", name.unwrap_or(""));
                 print_til_type_function(fmt, section, &name, inner_fun)
             } else {
@@ -356,7 +357,13 @@ fn print_til_type(
                 if print_pointer_space {
                     write!(fmt, " ")?;
                 }
-                write!(fmt, "*{}", name.unwrap_or(""))
+                let modifier = match pointer.modifier {
+                    None => "",
+                    Some(idb_rs::til::pointer::PointerModifier::Ptr32) => "__ptr32 ",
+                    Some(idb_rs::til::pointer::PointerModifier::Ptr64) => "__ptr64 ",
+                    Some(idb_rs::til::pointer::PointerModifier::Restricted) => "__restricted ",
+                };
+                write!(fmt, "*{modifier}{}", name.unwrap_or(""))
             }
         }
         Type::Function(function) => {

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -148,7 +148,7 @@ fn print_til_section(mut fmt: impl Write, section: &TILSection) -> std::io::Resu
     writeln!(
         fmt,
         "default_align = {} sizeof(bool) = {} sizeof(long)  = {} sizeof(llong) = {}",
-        section.def_align,
+        section.def_align.map(|x| x.get()).unwrap_or(0),
         section.size_bool,
         section.sizeof_long(),
         section.sizeof_long_long(),

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -445,19 +445,21 @@ fn print_til_type(
                 print_type_prefix,
             ),
             Enum::NonRef {
-                members, bytesize, ..
+                members,
+                storage_size,
+                ..
             } => {
                 let name = name.unwrap_or("");
                 write!(fmt, "enum {name} ")?;
-                if let Some(bytesize) = bytesize {
+                if let Some(storage_size) = storage_size {
                     let bits_required = members
                         .iter()
                         .map(|(_, value)| u64::BITS - value.leading_zeros())
                         .max()
                         .map(|x| x.max(1)) //can't have a value being represented in 0bits
                         .unwrap_or(8);
-                    if bits_required / 8 < bytesize.get().into() {
-                        write!(fmt, ": __int{} ", bytesize.get() as usize * 8)?;
+                    if bits_required / 8 < storage_size.get().into() {
+                        write!(fmt, ": __int{} ", storage_size.get() as usize * 8)?;
                     }
                 }
                 write!(fmt, "{{")?;
@@ -468,7 +470,7 @@ fn print_til_type(
                         .unwrap_or("_");
                     write!(fmt, "{name} = {value:#X}")?;
                     // TODO find this in InnerRef
-                    match bytesize.map(NonZeroU8::get) {
+                    match storage_size.map(NonZeroU8::get) {
                         Some(8) => write!(fmt, "LL")?,
                         _ => {}
                     }

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -1,0 +1,331 @@
+use idb_rs::id0::Compiler;
+use idb_rs::til::r#enum::Enum;
+use idb_rs::til::r#struct::Struct;
+use idb_rs::til::section::TILSection;
+use idb_rs::til::union::Union;
+use idb_rs::til::Basic;
+use idb_rs::til::Type;
+
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Write;
+use std::num::NonZeroU8;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// Parse IDA files and output it's data
+#[derive(Clone, Debug, Parser)]
+struct Args {
+    #[command(subcommand)]
+    operation: Operation,
+    /// til-file
+    #[arg(short, long)]
+    input: PathBuf,
+}
+
+/// File type to parse
+#[derive(Clone, Debug, Subcommand)]
+enum Operation {
+    /// show til-file contents
+    PrintTil,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let file = BufReader::new(File::open(&args.input).unwrap());
+    let section = TILSection::parse(file).unwrap();
+    match &args.operation {
+        Operation::PrintTil => print_til_section(std::io::stdout(), &section).unwrap(),
+    }
+}
+
+fn print_til_section(mut fmt: impl Write, section: &TILSection) -> std::io::Result<()> {
+    // TODO add missing dependencies: "Warning: gnulnx_x64: No such file or directory"
+    writeln!(fmt)?;
+    writeln!(fmt, "TYPE INFORMATION LIBRARY CONTENTS")?;
+
+    // the description of the file
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b710
+    writeln!(
+        fmt,
+        "Description: {}",
+        core::str::from_utf8(&section.title).unwrap()
+    )?;
+
+    // flags from the section header
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b721
+    write!(fmt, "Flags      : {:04X}", section.flags.as_raw())?;
+    if section.flags.is_zip() {
+        write!(fmt, " compressed")?;
+    }
+    if section.flags.has_macro_table() {
+        write!(fmt, " macro_table_present")?;
+    }
+    if section.flags.have_extended_sizeof_info() {
+        write!(fmt, " extended_sizeof_info")?;
+    }
+    if section.flags.is_universal() {
+        write!(fmt, " universal")?;
+    }
+    if section.flags.has_ordinal() {
+        write!(fmt, " ordinals_present")?;
+    }
+    if section.flags.has_type_aliases() {
+        write!(fmt, " aliases_present")?;
+    }
+    if section.flags.has_extra_stream() {
+        write!(fmt, " extra_streams")?;
+    }
+    if section.flags.has_size_long_double() {
+        write!(fmt, " sizeof_long_double")?;
+    }
+    writeln!(fmt)?;
+
+    // base tils
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b775
+    write!(fmt, "Base tils  : ")?;
+    // TODO get the base tils
+    //for (i, base) in section.base_tils.iter().enumerate() {
+    //    write!(fmt, "{}", base)?;
+    //    if i != section.base_tils.len() - 1 {
+    //        write!(fmt, ", ")?;
+    //    }
+    //}
+    writeln!(fmt, "")?;
+
+    // compiler name
+    // TODO decode thigs at: InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b7ed
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b8c5
+    let compiler_name = match section.compiler_id {
+        Compiler::Unknown => "Unknown",
+        Compiler::VisualStudio => "Visual C++",
+        Compiler::Borland => "Borland C++",
+        Compiler::Watcom => "Watcom C++",
+        Compiler::Gnu => "GNU C++",
+        Compiler::VisualAge => "Visual Age C++",
+        Compiler::Delphi => "Delphi",
+        Compiler::Other => "?",
+    };
+    writeln!(fmt, "Compiler   : {}", compiler_name)?;
+
+    // alignment
+    // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x40b8e4
+    writeln!(
+        fmt,
+        "default_align = {} sizeof(bool) = {} sizeof(long)  = {} sizeof(llong) = {}",
+        section.def_align, section.size_bool, section.size_long, section.size_long_long
+    )?;
+    writeln!(
+        fmt,
+        "sizeof(enum) = {} sizeof(int) = {} sizeof(short) = {}",
+        section.size_enum.map(NonZeroU8::get).unwrap_or(0),
+        section.size_int,
+        section.size_short
+    )?;
+    writeln!(
+        fmt,
+        "sizeof(long double) = {}",
+        section.size_long_double.map(NonZeroU8::get).unwrap_or(0)
+    )?;
+    writeln!(fmt)?;
+
+    // Print Symbols
+    writeln!(fmt, "SYMBOLS")?;
+    for symbol in &section.symbols {
+        // TODO get the len for type
+        let len = 0;
+        write!(fmt, "{len:08X} {:08X}          ", symbol.ordinal)?;
+        let name = std::str::from_utf8(&symbol.name).unwrap();
+        print_til_type(&mut fmt, section, Some(name), &symbol.tinfo)?;
+        writeln!(fmt, ";")?;
+    }
+    writeln!(fmt)?;
+
+    writeln!(fmt, "Types")?;
+    writeln!(fmt, "(enumerated by ordinals)")?;
+    let mut types_sort: Vec<_> = section.types.iter().collect();
+    types_sort.sort_by_key(|ord| ord.ordinal);
+    for symbol in types_sort {
+        // TODO get the len for type
+        let len = 0;
+        write!(fmt, "{len:08X}    {}. ", symbol.ordinal)?;
+        let name = std::str::from_utf8(&symbol.name).unwrap();
+        print_til_type(&mut fmt, section, Some(name), &symbol.tinfo)?;
+        writeln!(fmt, ";")?;
+    }
+    writeln!(fmt, "(enumerated by names)")?;
+    for symbol in &section.types {
+        if symbol.name.len() == 0 {
+            continue;
+        }
+        // TODO get the len for type
+        let len = 0;
+        write!(fmt, "{len:08X} ")?;
+        let name = std::str::from_utf8(&symbol.name).unwrap();
+        print_til_type(&mut fmt, section, Some(name), &symbol.tinfo)?;
+        writeln!(fmt, ";")?;
+    }
+    writeln!(fmt)?;
+
+    // macros
+    writeln!(fmt, "MACROS")?;
+    let macro_iter = section.macros.iter().map(|x| x.iter()).flatten();
+    for macro_entry in macro_iter {
+        let name = std::str::from_utf8(&macro_entry.name).unwrap();
+        let value = std::str::from_utf8(&macro_entry.value).unwrap();
+        writeln!(fmt, "{name} = {value}")?;
+    }
+    writeln!(fmt)?;
+
+    // TODO streams
+
+    let macros_num = section
+        .macros
+        .as_ref()
+        .map(|macros| macros.len())
+        .unwrap_or(0);
+    let types_num = section.types.len();
+    let symbols_num = section.symbols.len();
+    writeln!(
+        fmt,
+        "Total {symbols_num} symbols, {types_num} types, {macros_num} macros"
+    )
+}
+
+fn print_til_type(
+    fmt: &mut impl Write,
+    section: &TILSection,
+    name: Option<&str>,
+    til_type: &Type,
+) -> std::io::Result<()> {
+    let name_helper = name.map(|name| format!(" {name}")).unwrap_or(String::new());
+    match til_type {
+        Type::Basic(Basic::Char) => write!(fmt, "char{name_helper}",),
+        Type::Basic(Basic::Void) => write!(fmt, "void{name_helper}",),
+        Type::Basic(Basic::SegReg) => write!(fmt, "SegReg{name_helper}"),
+        Type::Basic(Basic::Unknown { bytes }) => write!(fmt, "unknown{bytes}{name_helper}"),
+        Type::Basic(Basic::Int { bytes, is_signed }) => {
+            match is_signed {
+                Some(false) => write!(fmt, "unsigned ")?,
+                Some(true) | None => {}
+            }
+            write!(fmt, "__int{}{name_helper}", bytes.get() * 8)
+        }
+        Type::Basic(Basic::Float { bytes }) if bytes.get() == 4 => {
+            write!(fmt, "float{name_helper}")
+        }
+        Type::Basic(Basic::Float { bytes }) if bytes.get() == 8 => {
+            write!(fmt, "double{name_helper}")
+        }
+        Type::Basic(Basic::Float { bytes }) => write!(fmt, "float{bytes}{name_helper}"),
+        Type::Basic(Basic::Bool { bytes }) if bytes.get() == 1 => write!(fmt, "bool{name_helper}"),
+        Type::Basic(Basic::Bool { bytes }) => write!(fmt, "bool{bytes}{name_helper}"),
+        Type::Pointer(pointer) => {
+            // TODO name
+            write!(fmt, "*")?;
+            print_til_type(fmt, section, name, &pointer.typ)
+        }
+        Type::Function(_function) => write!(fmt, "todo!()"),
+        Type::Array(array) => {
+            print_til_type(fmt, section, None, &array.elem_type)?;
+            write!(fmt, "{name_helper}[{}]", array.nelem)
+        }
+        Type::Typedef(typedef) => match typedef {
+            idb_rs::til::Typedef::Ordinal(ord) => write!(fmt, "todo!(ord({}))", ord),
+            idb_rs::til::Typedef::Name(vec) => {
+                let name = core::str::from_utf8(&vec).unwrap();
+                write!(fmt, "{name}{name_helper}")
+            }
+        },
+        Type::Struct(str_type) => match str_type {
+            Struct::Ref {
+                ref_type,
+                taudt_bits: _,
+            } => {
+                // TODO name
+                write!(fmt, "&")?;
+                print_til_type(fmt, section, None, &*ref_type)
+            }
+            Struct::NonRef {
+                effective_alignment: _,
+                taudt_bits: _,
+                members,
+            } => {
+                let name = name.unwrap_or("");
+                write!(fmt, "struct {name} {{")?;
+                for member in members {
+                    print_til_type(
+                        fmt,
+                        section,
+                        member
+                            .name
+                            .as_ref()
+                            .map(|x| core::str::from_utf8(&x).unwrap()),
+                        &member.member_type,
+                    )?;
+                    write!(fmt, ";")?;
+                }
+                write!(fmt, "}}")
+            }
+        },
+        Type::Union(union_type) => match union_type {
+            Union::Ref {
+                ref_type,
+                taudt_bits: _,
+            } => {
+                write!(fmt, "&")?;
+                print_til_type(fmt, section, None, &*ref_type)
+            }
+            Union::NonRef {
+                effective_alignment: _,
+                taudt_bits: _,
+                members,
+            } => {
+                let name = name.unwrap_or("");
+                write!(fmt, "union {name} {{")?;
+                for (member_name, member) in members {
+                    print_til_type(
+                        fmt,
+                        section,
+                        member_name
+                            .as_ref()
+                            .map(|x| core::str::from_utf8(&x).unwrap()),
+                        member,
+                    )?;
+                    write!(fmt, ";")?;
+                }
+                write!(fmt, "}}")
+            }
+        },
+        Type::Enum(enum_type) => match enum_type {
+            Enum::Ref {
+                ref_type,
+                taenum_bits: _,
+            } => {
+                write!(fmt, "&")?;
+                print_til_type(fmt, section, None, &*ref_type)
+            }
+            Enum::NonRef {
+                group_sizes: _,
+                taenum_bits: _,
+                bte: _,
+                members,
+                bytesize: _,
+            } => {
+                let name = name.unwrap_or("");
+                write!(fmt, "enum {name} {{")?;
+                for (member_name, value) in members {
+                    let name = member_name
+                        .as_ref()
+                        .map(|x| core::str::from_utf8(&x).unwrap())
+                        .unwrap_or("_");
+                    write!(fmt, "{name} = {value:#x},")?;
+                }
+                write!(fmt, "}}")
+            }
+        },
+        Type::Bitfield(_bitfield) => write!(fmt, "todo!()"),
+    }
+}

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -251,7 +251,12 @@ fn print_til_section(mut fmt: impl Write, section: &TILSection) -> std::io::Resu
         .as_ref()
         .map(|macros| macros.len())
         .unwrap_or(0);
-    let types_num = section.types.len();
+    let alias_num = section
+        .type_ordinal_alias
+        .as_ref()
+        .map(Vec::len)
+        .unwrap_or(0);
+    let types_num = section.types.len() + alias_num;
     let symbols_num = section.symbols.len();
     writeln!(
         fmt,
@@ -445,7 +450,7 @@ fn print_til_type(
                         .as_ref()
                         .map(|x| core::str::from_utf8(x).unwrap())
                         .unwrap_or("_");
-                    write!(fmt, "{name} = {value:#x},")?;
+                    write!(fmt, "{name} = {value:#X},")?;
                 }
                 write!(fmt, "}}")
             }

--- a/src/tools/tilib.rs
+++ b/src/tools/tilib.rs
@@ -377,14 +377,12 @@ fn print_til_type(
                     let ty = section
                         .get_ord(idb_rs::id0::Id0TilOrd { ord: (*ord).into() })
                         .unwrap();
-                    print_til_type_name(fmt, &ty.name, &ty.tinfo, print_type_prefix)?;
+                    print_til_type_name(fmt, &ty.name, &ty.tinfo, false)?;
                 }
                 idb_rs::til::Typedef::Name(name) => {
                     let ty = section.get_name(name);
                     match ty {
-                        Some(ty) => {
-                            print_til_type_name(fmt, &ty.name, &ty.tinfo, print_type_prefix)?
-                        }
+                        Some(ty) => print_til_type_name(fmt, &ty.name, &ty.tinfo, false)?,
                         // if we can't find the type, just print the name
                         None => write!(fmt, "{}", core::str::from_utf8(name).unwrap())?,
                     }

--- a/src/tools/tools.rs
+++ b/src/tools/tools.rs
@@ -37,6 +37,8 @@ mod dump_dirtree_bookmarks_structplace;
 use dump_dirtree_bookmarks_structplace::dump_dirtree_bookmarks_structplace;
 mod dump_dirtree_bookmarks_tiplace;
 use dump_dirtree_bookmarks_tiplace::dump_dirtree_bookmarks_tiplace;
+mod tilib;
+use tilib::tilib_print;
 
 use idb_rs::{id0::ID0Section, IDBParser};
 
@@ -106,6 +108,8 @@ enum Operation {
     DumpDirtreeBookmarksIdaplace,
     DumpDirtreeBookmarksStructplace,
     DumpDirtreeBookmarksTiplace,
+    /// Print all til types from file and it's information
+    PrintTilib,
 }
 
 ///// Split the IDB file into it's decompressed sectors. Allow IDB and I64 files.
@@ -175,5 +179,6 @@ fn main() -> Result<()> {
         Operation::DumpDirtreeBookmarksIdaplace => dump_dirtree_bookmarks_idaplace(&args),
         Operation::DumpDirtreeBookmarksStructplace => dump_dirtree_bookmarks_structplace(&args),
         Operation::DumpDirtreeBookmarksTiplace => dump_dirtree_bookmarks_tiplace(&args),
+        Operation::PrintTilib => tilib_print(&args),
     }
 }


### PR DESCRIPTION
* [X] Fix id0 big til types parsing and ignoring errors.
* [X] Add extra verification for correct til type parsing.
* [X] Add test tool tilib
* [X] Parse macros params.
* [ ] Implement til type attribute parsing
  * [x] const/volatile
  * [ ] Extern
  * [x] Pointer
    * [x] Pointer Type
    * [x] `_shitfted` and alike
  * [x] Array
  * [x] Function
    * [x] Calling Convention
    * [x] Call Distance
    * [x] Closure
  * [x] Union
  * [ ] Struct
    * [x] Submember attribute
    * [ ] Missing cpp_obj att?
  * [x] Enum
    * [x] Output format
    * [x] Sub Arrays
    * [x] #22
  * [x] Bitfield
* [X] Fix field names
* [ ] Fix symbol with extra `_` in name
* [ ] Implement type size calculation, then fix the alignment calculation.