### PR TITLE
Parse bare BT_UNK and harden function dirtree dump

### DIFF
--- a/src/id0/root_info.rs
+++ b/src/id0/root_info.rs
@@ -275,7 +275,10 @@ impl<K: IDAKind> RootInfo<K> {
         match version {
             // TODO old version may contain extra data at the end with unknown purpose
             ..=699 => {}
-            700.. => ensure!(input.is_empty(), "Data left after the IDBParam",),
+            700.. => {
+                #[cfg(feature = "restrictive")]
+                ensure!(input.is_empty(), "Data left after the IDBParam");
+            }
         }
         Ok(param)
     }

--- a/src/til.rs
+++ b/src/til.rs
@@ -392,9 +392,10 @@ impl Basic {
             // InnerRef fb47f2c2-3c08-4d40-b7ab-3c7736dce31d 0x480874
             BT_UNK => {
                 let bytes = match btmt {
-                    BTMT_SIZE0 => {
-                        return Err(anyhow!("forbidden use of BT_UNK"))
-                    }
+                    // A bare `BT_UNK` (type byte 0x00) is IDA's unknown type of unspecified
+                    // size; treat it like `BT_UNKNOWN` rather than rejecting it, since it shows
+                    // up in real databases (e.g. as a function argument/return type).
+                    BTMT_SIZE0 => 0,
                     BTMT_SIZE12 => 2,  // BT_UNK_WORD
                     BTMT_SIZE48 => 8,  // BT_UNK_QWORD
                     BTMT_SIZE128 => 0, // BT_UNKNOWN

--- a/src/tools/dump_dirtree_funcs.rs
+++ b/src/tools/dump_dirtree_funcs.rs
@@ -20,13 +20,13 @@ fn dump_inner<K: IDAKind>((id0, id1, id2): Id0Id1Id2Variant<K>) -> Result<()> {
     if let Some(dirtree) = id0.dirtree_function_address()? {
         print_dirtree(
             |entry| {
-                print_function(
-                    &id0,
-                    &id1,
-                    id2.as_ref(),
-                    Address::from_raw(*entry),
-                )
-                .unwrap()
+                let address = Address::from_raw(*entry);
+                if let Err(err) =
+                    print_function(&id0, &id1, id2.as_ref(), address)
+                {
+                    // Don't let a single unparsable function abort the whole dump.
+                    println!("{:#x}: <error: {err:#}>", address.into_raw());
+                }
             },
             &dirtree,
         );
@@ -45,14 +45,12 @@ pub fn print_function<K: IDAKind>(
     let root_info = id0.ida_info(root_info_idx)?;
     let image_base = root_info.netdelta();
     let info = AddressInfo::new(id0, id1, id2, image_base, address);
-    let name = info
-        .as_ref()
-        .and_then(|info| info.label().transpose())
-        .transpose()?;
+    // Tolerate per-function label/type parse failures so one bad entry doesn't abort the dump;
+    // such a function simply prints without the failing piece.
+    let name = info.as_ref().and_then(|info| info.label().ok().flatten());
     let ty = info
         .as_ref()
-        .and_then(|info| info.tinfo(&root_info).transpose())
-        .transpose()?;
+        .and_then(|info| info.tinfo(&root_info).ok().flatten());
 
     print!("{:#x}:", address.into_raw());
     match (name, ty) {


### PR DESCRIPTION
A type byte of 0x00 (BT_UNK with BTMT_SIZE0) is IDA's unknown type of
unspecified size and appears in real databases as function argument/return
types, but it was rejected with "forbidden use of BT_UNK", aborting type
parsing for any function that used it. Parse it like BT_UNKNOWN (unknown,
unspecified size) instead.

Also harden `dump-dirtree-funcs`: a single function whose label or type fails
to parse no longer panics the whole dump (it previously `.unwrap()`ed
`print_function`). Per-function parse errors are tolerated, and an entry that
still fails to print is emitted with an inline error note.

This let a full function-dirtree dump of a large arm64 database complete with
all ~150k functions instead of aborting after the first unparsable type.